### PR TITLE
Added CircleCI testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/test-runner"]
+	path = tests/test-runner
+	url = https://github.com/tozd/meteor-test-runner.git

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+checkout:
+  post:
+    - git submodule sync
+    - git submodule update --init --recursive
+machine:
+  node:
+    version: 0.10.33
+  pre:
+    - curl https://install.meteor.com | /bin/sh
+dependencies:
+  override:
+    - npm install selenium-webdriver
+    - meteor list
+test:
+  override:
+    - tests/test-runner/test-all.sh

--- a/circle.yml
+++ b/circle.yml
@@ -7,10 +7,11 @@ machine:
     version: 0.10.33
   pre:
     - curl https://install.meteor.com | /bin/sh
+    - git clone -b devel https://github.com/meteor/meteor.git /tmp/meteor
 dependencies:
   override:
     - npm install selenium-webdriver
     - meteor list
 test:
   override:
-    - tests/test-runner/test-all.sh
+    - METEOR_WAREHOUSE_DIR=/tmp/meteor tests/test-runner/test-all.sh


### PR DESCRIPTION
It does not really work, because running (what is more or less what test runner does internally):

```
export PACKAGE_DIRS=packages
meteor test-packages --once --driver-package 'test-in-console' -p 4096 packages/blaze
```

throws the following error:

```
=> Build failed:                              
   
   While selecting package versions:
   error: No version of blaze satisfies all constraints: @=2.1.4-beta.11, @=2.1.3
   Constraints on package "blaze":
   * blaze@=2.1.4-beta.11 <- top level
   * blaze@=2.1.3 <- top level
   * blaze@2.1.3 <- ui 1.0.8 <- boilerplate-generator 1.0.4 <- webapp 1.2.3 <- autoupdate 1.2.4
   * blaze@2.1.3 <- test-helpers 1.0.5 <- local-test:blaze 2.1.4-beta.11
   
   No version of blaze-tools satisfies all constraints: @=1.0.5-beta.11, @=1.0.4
   Constraints on package "blaze-tools":
   * blaze-tools@=1.0.5-beta.11 <- top level
   * blaze-tools@=1.0.4 <- top level
   
   No version of html-tools satisfies all constraints: @=1.0.6-beta.11, @=1.0.5
   Constraints on package "html-tools":
   * html-tools@=1.0.6-beta.11 <- top level
   * html-tools@=1.0.5 <- top level
   
   No version of htmljs satisfies all constraints: @=1.0.6-beta.11, @=1.0.5
   Constraints on package "htmljs":
   * htmljs@=1.0.6-beta.11 <- top level
   * htmljs@=1.0.5 <- top level
   * htmljs@1.0.5 <- boilerplate-generator 1.0.4 <- webapp 1.2.3 <- autoupdate 1.2.4
   
   No version of spacebars-compiler satisfies all constraints: @=1.0.8-beta.11, @=1.0.7
   Constraints on package "spacebars-compiler":
   * spacebars-compiler@=1.0.8-beta.11 <- top level
   * spacebars-compiler@=1.0.7 <- top level
   * spacebars-compiler@1.0.7 <- boilerplate-generator 1.0.4 <- webapp 1.2.3 <- autoupdate 1.2.4
   
   No version of spacebars satisfies all constraints: @=1.0.8-beta.11, @=1.0.7
   Constraints on package "spacebars":
   * spacebars@=1.0.8-beta.11 <- top level
   * spacebars@=1.0.7 <- top level
   * spacebars@1.0.7 <- boilerplate-generator 1.0.4 <- webapp 1.2.3 <- autoupdate 1.2.4
   
   No version of templating satisfies all constraints: @=1.1.6-beta.11, @=1.1.5
   Constraints on package "templating":
   * templating@=1.1.6-beta.11 <- top level
   * templating@=1.1.5 <- top level
```