### PR TITLE
Fix slack url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Slack Status](http://slack.blazejs.com/badge.svg)](http://slack.blazejs.com)
 [![CircleCI Status](https://circleci.com/gh/meteor/blaze.svg?style=shield)](https://circleci.com/gh/meteor/blaze)
 
 # Meteor Blaze
@@ -7,7 +6,7 @@ This is a repository for Meteor Blaze project.
 
 ## How to get involved
 
-1. [Join](http://slack.blazejs.com) our [Slack chat](https://blazejs.slack.com/).
+1. [Join](http://blazejs.slack.com) our [Slack chat](https://blazejs.slack.com/).
 1. See the current [roadmap](https://github.com/meteor/blaze/milestones) and consider
    helping with any of the tasks on the roadmap.
 1. Open issues and/or participate in discussions about bugs and feature requests.


### PR DESCRIPTION
Fix the link to the Slack https://github.com/meteor/blaze/issues/51, somehow the slack spent working on different subdomains... and the badge no longer rendering. I removed to don't be a broken image.