### PR TITLE
Fix links to source

### DIFF
--- a/site/themes/custom-meteor/layout/page.ejs
+++ b/site/themes/custom-meteor/layout/page.ejs
@@ -8,7 +8,7 @@
   <div id="content">
     <h1><%- page.title %></h1>
     <p class="edit-discuss-links">
-      <a href="https://github.com/<%- config.github_repo || 'meteor/blaze' %>/tree/master/<%- config.content_root || 'content' %>/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">Edit on GitHub</a>
+      <a href="https://github.com/<%- config.github_repo || 'meteor/blaze' %>/tree/master/site/<%- config.content_root || 'source' %>/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">Edit on GitHub</a>
       <% if (page.discourseTopicId) { %>
         |
         <a href="https://forums.meteor.com/t/<%- page.discourseTopicId %>">Discuss on the Blaze Forums</a>
@@ -38,13 +38,13 @@
       <% } %>
     </div>
     <p class="edit-link">
-      <a href="https://github.com/meteor/guide/tree/master/content/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">Edit this page on GitHub</a>
+      <a href="https://github.com/meteor/blaze/tree/master/site/source/<%- page.path.replace(/\.html$/, '.md') %>" target="_blank">Edit this page on GitHub</a>
     </p>
     <% if (page.discourseTopicId) { %>
       <div id='discourse-comments'></div>
 
       <script type="text/javascript">
-        DiscourseEmbed = { discourseUrl: 'http://forums.blazejs.com/',
+        DiscourseEmbed = { discourseUrl: 'http://forums.meteor.com/',
                            topicId: <%- page.discourseTopicId %> };
 
         (function() {


### PR DESCRIPTION
Correcting the first item in this issue: https://github.com/meteor/blaze/issues/66
> links to source code from documentation do not work