### PR TITLE
Resources Link Update

### DIFF
--- a/site/source/index.md
+++ b/site/source/index.md
@@ -198,9 +198,9 @@ Blaze will get better support for using it outside of Meteor, such as regular st
 
 # Resources
 
-* [Templates API](http://docs.meteor.com/#templates_api)
-* [Blaze API](http://docs.meteor.com/#blaze)
-* [Spacebars syntax](https://github.com/meteor/meteor/blob/devel/packages/spacebars/README.md)
+* [Templates API](http://blazejs.org/templates.html)
+* [Blaze API](http://blazejs.org/blaze.html)
+* [Spacebars syntax](https://docs.meteor.com/packages/spacebars.html)
 
 # Packages
 


### PR DESCRIPTION
Templates API and Blaze API links directed to the Meteor Guide which then redirects back to a page on blazejs.org. Those resource links have been updated to direct straight to the blazejs.org pages.

The Spacebars link directs to a 404 on Github and there is Spacebars package documentation on Meteor docs, so that link has been updated to the docs.