### PR TITLE
Fix 'Edit on GitHub' links

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -32,7 +32,7 @@ sidebar_categories:
     - api/blaze
     - api/spacebars
 github_repo: 'meteor/blaze'
-content_root: 'site'
+content_root: 'site/source'
 
 # themeing
 favicon: '/logo/icon.ico'


### PR DESCRIPTION
update hexo config file to point the correct github path
as discussed on commit 6af0a1b1b63e93c7bd639fe07e5c934ad7f1c0a4