### PR TITLE
Update themes submodule

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -17,6 +17,8 @@ apis:
   #   indexName: meteor_api_guide
 versions:
   - '2.1.8'
+
+# This setting also defines the page order used to generate the Previous/Next links at the bottom of each page
 sidebar_categories:
   null:
     - index
@@ -31,6 +33,7 @@ sidebar_categories:
     - api/templates
     - api/blaze
     - api/spacebars
+
 github_repo: 'meteor/blaze'
 content_root: 'site/source'
 

--- a/site/source/api/blaze.md
+++ b/site/source/api/blaze.md
@@ -1,6 +1,5 @@
 ---
 title: Blaze
-order: 8
 description: Documentation of how to use Blaze, Meteor's reactive rendering engine.
 ---
 

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -1,6 +1,5 @@
 ---
 title: Spacebars
-order: 9
 description: Documentation of Meteor's `spacebars` package.
 ---
 

--- a/site/source/api/templates.md
+++ b/site/source/api/templates.md
@@ -1,6 +1,5 @@
 ---
 title: Templates
-order: 7
 description: Documentation of Meteor's template API.
 ---
 

--- a/site/source/guide/introduction.md
+++ b/site/source/guide/introduction.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction
-order: 1
 description: How to use Blaze, Meteor's frontend rendering system, to build usable and maintainable user interfaces.
 ---
 

--- a/site/source/guide/reusable-components.md
+++ b/site/source/guide/reusable-components.md
@@ -1,7 +1,6 @@
 ---
 title: Reusable components in Blaze
-order: 3
-description: 
+description:
 ---
 
 In [UI/UX article](https://guide.meteor.com/ui-ux.html#smart-components) we discussed the merits of creating reusable components that interact with their environment in clear and minimal ways.

--- a/site/source/guide/reusing-code.md
+++ b/site/source/guide/reusing-code.md
@@ -1,7 +1,6 @@
 ---
 title: Reusing code in Blaze
-order: 5
-description: 
+description:
 ---
 
 It's common to want to reuse code between two otherwise unrelated components. There are two main ways to do this in Blaze.

--- a/site/source/guide/smart-components.md
+++ b/site/source/guide/smart-components.md
@@ -1,7 +1,6 @@
 ---
 title: Writing smart components with Blaze
-order: 4
-description: 
+description:
 ---
 
 Some of your components will need to access state outside of their data context---for instance, data from the server via subscriptions or the contents of client-side store. As discussed in the [data loading](https://guide.meteor.com/data-loading.html#patterns) and [UI](https://guide.meteor.com/ui-ux.html#smart-components) articles, you should be careful and considered in how use such smart components.

--- a/site/source/guide/spacebars.md
+++ b/site/source/guide/spacebars.md
@@ -1,7 +1,6 @@
 ---
 title: Spacebars templates
-order: 2
-description: 
+description:
 ---
 
 Spacebars is a handlebars-like templating language, built on the concept of rendering a reactively changing *data context*. Spacebars templates look like simple HTML with special "mustache" tags delimited by curly braces: `{% raw %}{{ }}{% endraw %}`.
@@ -164,7 +163,7 @@ A block helper, called with `{% raw %}{{# }}{% endraw %}` is a helper that takes
   {{#myIf condition=true}}
     <h1>I'll be rendered!</h1>
   {{else}}
-    <h1>I won't be rendered</h1>    
+    <h1>I won't be rendered</h1>
   {{/myIf}}
 </template>
 ```

--- a/site/source/guide/understanding-blaze.md
+++ b/site/source/guide/understanding-blaze.md
@@ -1,6 +1,5 @@
 ---
 title: Understanding Blaze
-order: 6
 description:
 ---
 

--- a/site/source/index.md
+++ b/site/source/index.md
@@ -1,10 +1,9 @@
 ---
 title: Overview
-order: 0
 description:
 ---
 
-Blaze is a powerful library for creating user interfaces by writing reactive HTML templates. Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM. Instead, familiar template directives like `{% raw %}{{#if}}{% endraw %}` and `{% raw %}{{#each}}{% endraw %}` integrates with [Tracker's](https://docs.meteor.com/api/tracker.html) "transparent reactivity" and [Minimongo's](https://docs.meteor.com/api/collections.html) database cursors so that the DOM updates automatically. 
+Blaze is a powerful library for creating user interfaces by writing reactive HTML templates. Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM. Instead, familiar template directives like `{% raw %}{{#if}}{% endraw %}` and `{% raw %}{{#each}}{% endraw %}` integrates with [Tracker's](https://docs.meteor.com/api/tracker.html) "transparent reactivity" and [Minimongo's](https://docs.meteor.com/api/collections.html) database cursors so that the DOM updates automatically.
 
 ## Quick Start
 


### PR DESCRIPTION
This picks up changes I recently made to the hexo-theme-meteor repo
- Page order is now defined solely by `sidebar_categories` in _config.yml, which is more straightforward than editing the `order` field in each page's front matter block

See [here](https://github.com/meteor/guide/issues/556) for the discussion that prompted this change.