### PR TITLE
Remove redundant code/text, correct list of falsy values, edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## What is Blaze?
 
-Blaze is a powerful library for creating user interfaces by writing reactive HTML templates.  Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM.  Instead, familiar template directives like ``{{#if}}`` and ``{{#each}}`` integrate with [Tracker's](https://github.com/meteor/meteor/tree/master/packages/tracker) "transparent reactivity" and [Minimongo's](https://meteor.com/mini-databases) database cursors so that the DOM updates automatically. 
+Blaze is a powerful library for creating user interfaces by writing reactive HTML templates.  Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM.  Instead, familiar template directives like ``{{#if}}`` and ``{{#each}}`` integrate with [Tracker's](https://github.com/meteor/meteor/tree/master/packages/tracker) "transparent reactivity" and [Minimongo's](https://meteor.com/mini-databases) database cursors so that the DOM updates automatically.
 
 ### Blaze has two major parts:
 
@@ -28,9 +28,9 @@ Blaze is a powerful library for creating user interfaces by writing reactive HTM
 
 ## Quick Start
 
-Blaze is a [Meteor](http://meteor.com/)-only package for now. Sooner we will have Blaze on npm so you can use it in your stack.
+Blaze is a [Meteor](http://meteor.com/)-only package for now. Soon we will have Blaze on npm so you can use it in your stack.
 
-A new Meteor project has Blaze included.
+Each new Meteor project you create has Blaze included (the `blaze-html-templates` package).
 
 ## Get involved
 

--- a/site/source/guide/smart-components.md
+++ b/site/source/guide/smart-components.md
@@ -3,7 +3,7 @@ title: Writing smart components with Blaze
 description:
 ---
 
-Some of your components will need to access state outside of their data context---for instance, data from the server via subscriptions or the contents of client-side store. As discussed in the [data loading](https://guide.meteor.com/data-loading.html#patterns) and [UI](https://guide.meteor.com/ui-ux.html#smart-components) articles, you should be careful and considered in how use such smart components.
+Some of your components will need to access state outside of their data context---for instance, data from the server via subscriptions or the contents of client-side store. As discussed in the [data loading](https://guide.meteor.com/data-loading.html#patterns) and [UI](https://guide.meteor.com/ui-ux.html#smart-components) articles, you should be careful and considered in how you use such smart components.
 
 All of the suggestions about reusable components apply to smart components. In addition:
 

--- a/site/source/guide/spacebars.md
+++ b/site/source/guide/spacebars.md
@@ -174,7 +174,7 @@ There are a few built-in block helpers that are worth knowing about:
 
 ### If / Unless
 
-The `{% raw %}{{#if}}{% endraw %}` and `{% raw %}{{#unless}}{% endraw %}` helpers are fairly straightforward but invaluable for controlling the control flow of a template. Both operate by evaluating and checking their single argument for truthiness. In JS `null`, `undefined`, `0`, `''`, `[]`, and `false` are considered "falsy", and all other values are "truthy".
+The `{% raw %}{{#if}}{% endraw %}` and `{% raw %}{{#unless}}{% endraw %}` helpers are fairly straightforward but invaluable for controlling the control flow of a template. Both operate by evaluating and checking their single argument for truthiness. In JS `null`, `undefined`, `0`, `''`, `NaN`, and `false` are considered "falsy", and all other values are "truthy".
 
 ```html
 {{#if something}}

--- a/site/source/index.md
+++ b/site/source/index.md
@@ -7,9 +7,9 @@ Blaze is a powerful library for creating user interfaces by writing reactive HTM
 
 ## Quick Start
 
-Blaze is a Meteor-only package for now. Sooner we will have Blaze on npm so you can use it in your stack.
+Blaze is a Meteor-only package for now. Soon we will have Blaze on npm so you can use it in your stack.
 
-A new Meteor project has Blaze included.
+Each new Meteor project you create has Blaze included (the `blaze-html-templates` package).
 
 ## Details
 
@@ -53,33 +53,6 @@ Here are two Spacebars templates from an example app called "Leaderboard" which 
 
 The template tags `{{name}}` and `{{score}}` refer to properties of the data context (the current player), while `players` and `selected` refer to helper functions.  Helper functions and event handlers are defined in JavaScript:
 
-
-```html
-<template name="leaderboard">
-  <ol class="leaderboard">
-    {{#each players}}
-      {{> player}}
-    {{else}}
-      {{> no_players}}
-    {{/each}}
-  </ol>
-</template>
-
-<template name="player">
-  <li class="player {{selected}}">
-    <span class="name">{{name}}</span>
-    <span class="score">{{score}}</span>
-  </li>
-</template>
-
-<template name="no_players">
-  <li class="no-players">
-    No players available
-  </li>
-</template>
-```
-
-The template tags `{{name}}` and `{{score}}` refer to properties of the data context (the current player), while `players` and `selected` refer to helper functions. Helper functions and event handlers are defined in JavaScript:
 
 ```javascript
 Template.leaderboard.helpers({
@@ -127,7 +100,7 @@ What this means for the developer is simple. You don't have to explicitly declar
 
 Blaze embraces popular template syntaxes such as Handlebars and Jade which are clean, readable, and familiar to developers coming from other frameworks.
 
-A good template language should clearly distinguish the special "template directives" (often enclosed in curly braces) from the HTML, and it should not obscure the structure of the resulting HTML. These properties make templating an easy concept to learn after static HTML (or alongside it),and make templates easy to read, easy to style with CSS, and easy to relate to the DOM.
+A good template language should clearly distinguish the special "template directives" (often enclosed in curly braces) from the HTML, and it should not obscure the structure of the resulting HTML. These properties make templating an easy concept to learn after static HTML (or alongside it), and make templates easy to read, easy to style with CSS, and easy to relate to the DOM.
 
 In contrast, some newer frameworks try to remake templates as just HTML (Angular, Polymer) or replace them with just JavaScript (React). These approaches tend to obscure either the structure of the template, or what is a real DOM element and what is not, or both. In addition, since templates are generally precompiled anyway as a best practice, it's really not important that raw template source code be browser-parsable. Meanwhile, the developer experience of reading, writing, and maintaining templates is hugely important.
 
@@ -137,7 +110,7 @@ Web developers often share snippets of HTML, JavaScript, and CSS, or publish the
 
 Blaze doesn't assume it owns the whole DOM, and it tries to make as few assumptions as possible about the DOM outside of its updates. It hooks into jQuery's clean-up routines to prevent memory leaks, and it preserves classes, attributes, and styles added to elements by jQuery or any third-party library.
 
-While it's certainly possible for Blaze and jQuery to step on each other's toes if you aren't careful, there are established patterns for keeping the peace, and Meteor users rightfully expect to be able to use the various widgets and enhancements cooked up by the broader web community in their apps.
+While it's certainly possible for Blaze and jQuery to step on each other's toes if you aren't careful, there are established patterns for keeping the peace, and Blaze developers rightfully expect to be able to use the various widgets and enhancements cooked up by the broader web community in their apps.
 
 ## Comparisons to other libraries
 
@@ -147,7 +120,7 @@ Compared to Ember, Blaze offers finer-grained, automatic DOM updates. Because Bl
 
 Compared to Angular and Polymer, Blaze has a gentler learning curve, simpler concepts, and nicer template syntax that cleanly separates template directives and HTML. Also, Blaze is targeted at today's browsers and not designed around a hypothetical "browser of the future."
 
-Compared to React, Blaze emphasizes HTML templates rather than JavaScript component classes.Templates are more approachable than JavaScript code and easier to read, write, and style with CSS. Instead of using Tracker, React relies on a combination of explicit "setState" calls and data-model diffing in order to achieve efficient rendering.
+Compared to React, Blaze emphasizes HTML templates rather than JavaScript component classes. Templates are more approachable than JavaScript code and easier to read, write, and style with CSS. Instead of using Tracker, React relies on a combination of explicit "setState" calls and data-model diffing in order to achieve efficient rendering.
 
 ## Future Work
 


### PR DESCRIPTION
- Removed redundant code block and text since
- `[]` is not falsy whereas NaN is
- Various spacing edits and minor text edits to (hopefully) make it a bit clearer
