### PR TITLE
Adding .blaze extension to compiler

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 ## vNEXT
 
+* Added support for `.blaze` file extension.
+  [#158](https://github.com/meteor/blaze/pull/158)
+
 ## v2.2.1, 2016-Dec-31
 
 * Reactive inline `style` attribute now preserves the internal order. Similarly for `class`.

--- a/packages/templating-compiler/compile-templates.js
+++ b/packages/templating-compiler/compile-templates.js
@@ -1,5 +1,5 @@
 Plugin.registerCompiler({
-  extensions: ['html'],
+  extensions: ['html', 'blaze'],
   archMatching: 'web',
   isTemplate: true
 }, () => new CachingHtmlCompiler(

--- a/site/source/guide/spacebars.md
+++ b/site/source/guide/spacebars.md
@@ -3,7 +3,7 @@ title: Spacebars templates
 description:
 ---
 
-Spacebars is a handlebars-like templating language, built on the concept of rendering a reactively changing *data context*. Spacebars templates look like simple HTML with special "mustache" tags delimited by curly braces: `{% raw %}{{ }}{% endraw %}`.
+Spacebars is a handlebars-like templating language, built on the concept of rendering a reactively changing *data context*. Spacebars templates look like simple HTML with special "mustache" tags delimited by curly braces: `{% raw %}{{ }}{% endraw %}` and can have the extensions `.html` or `.blaze` for file names.
 
 As an example, consider the `Todos_item` template from the Todos example app:
 


### PR DESCRIPTION
As discussed in meteor#97, I believe it would be nice if Blaze accept .blaze extensions to avoid conflicts in editor's syntax highlighters.