### PR TITLE
Fix Doc Tests and Deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -22,6 +22,7 @@ test:
     #    parallel: true
     - METEOR_COMMAND=/tmp/meteor/meteor tests/test-runner/test-all.sh:
         parallel: true
+    - cd site; npm run generate
 deployment:
   s3:
     branch: /^(master|version-.*)/

--- a/site/package.json
+++ b/site/package.json
@@ -9,7 +9,6 @@
     "canonical-json": "0.0.4",
     "handlebars": "^4.0.5",
     "hexo": "^3.1.0",
-    "hexo-s3-deploy": "^1.0.1",
     "hexo-generator-archive": "^0.1.2",
     "hexo-generator-category": "^0.1.2",
     "hexo-generator-index": "^0.1.2",
@@ -24,10 +23,11 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "hexo-s3-deploy": "meteor/hexo-s3-deploy#e36f6d046660040878bb5bedfc8422f526a78be6"
   },
   "scripts": {
     "prestart": "jsdoc/jsdoc.sh",
-    "start": "hexo serve",
+    "start": "hexo server",
     "predeploy": "jsdoc/jsdoc.sh",
     "deploy": "hexo-s3-deploy",
     "pregenerate": "jsdoc/jsdoc.sh",


### PR DESCRIPTION
Previously, the doc generation was only occurring during the deploy and therefore not able to detect that a PR introduced a doc-breaking change.

Also, without meteor/hexo-s3-deploy@278a408, a breaking change wouldn't even cause the deploy to fail.

This PR changes it so that the tests run even on a PR (i.e. hopefully on this PR) and will fail accordingly at that point.  I believe meteor/blaze#135 actually should have failed the build as it does not `hexo generate`

I ran into these problems while debugging a completely unrelated issue (more on that soon).