### PR TITLE
Add back raw/endraw to `{{#if}}/`{{#each}}` in intro to docs

### DIFF
--- a/site/source/index.md
+++ b/site/source/index.md
@@ -3,7 +3,7 @@ title: Overview
 description:
 ---
 
-Blaze is a powerful library for creating user interfaces by writing reactive HTML templates. Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM. Instead, familiar template directives like `{{#if}}` and `{{#each}}` integrates with [Tracker's](https://docs.meteor.com/api/tracker.html) "transparent reactivity" and [Minimongo's](https://docs.meteor.com/api/collections.html) database cursors so that the DOM updates automatically.
+Blaze is a powerful library for creating user interfaces by writing reactive HTML templates. Compared to using a combination of traditional templates and jQuery, Blaze eliminates the need for all the "update logic" in your app that listens for data changes and manipulates the DOM. Instead, familiar template directives like `{% raw %}{{#if}}{% endraw %}` and `{% raw %}{{#each}}{% endraw %}` integrates with [Tracker's](https://docs.meteor.com/api/tracker.html) "transparent reactivity" and [Minimongo's](https://docs.meteor.com/api/collections.html) database cursors so that the DOM updates automatically.
 
 ## Quick Start
 


### PR DESCRIPTION
meteor/blaze#135 seems to have introduced a change which broke `hexo generate` and no doc deployment has occurred since it was merged.

For example: #139 is not live and thus the duplicated content (which is what caused me to start researching this originally) is still on blazejs.org.  #137 is also not deployed.

More comments here:  https://github.com/meteor/blaze/pull/135#issuecomment-260718442:

`{% raw %}` and `{% endraw %}` are still required when the tag is a `{{# blah }}` statement (with the `#`, versus `{{blah}}`)

This PR simply adds them back.