### PR TITLE
Updated package.js for templating-tools and spacebars-compiler

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,7 @@
 ## vNEXT
+* Removed [minifier-js](https://github.com/meteor/meteor/tree/devel/packages/minifier-js) dependency from [templating-tools](https://github.com/meteor/blaze/tree/master/packages/templating-tools). If you need your template output to be minified, you must add the package to your app manually, by running `meteor add standard-minifier-js`. The package is included in a standard meteor app.
+* Based on [#236](https://github.com/meteor/blaze/pull/236).
+* Use [uglify-js](https://github.com/mishoo/UglifyJS) directly in [spacebars-compiler](https://github.com/meteor/blaze/tree/master/packages/spacebars-compiler) for beautification instead of [minifier-js](https://github.com/meteor/meteor/tree/devel/packages/minifier-js).
 
 ## v2.3.0, 2017-Jan-12
 

--- a/packages/spacebars-compiler/package.js
+++ b/packages/spacebars-compiler/package.js
@@ -5,7 +5,6 @@ Package.describe({
   git: 'https://github.com/meteor/blaze.git'
 });
 
-// Use uglify-js from NPM
 Npm.depends({
   'uglify-js': '2.7.5'
 });

--- a/packages/spacebars-compiler/package.js
+++ b/packages/spacebars-compiler/package.js
@@ -5,6 +5,11 @@ Package.describe({
   git: 'https://github.com/meteor/blaze.git'
 });
 
+// Use uglify-js from NPM
+Npm.depends({
+  'uglify-js': '2.7.5'
+});
+
 Package.onUse(function (api) {
   api.use('underscore@1.0.9');
 
@@ -21,11 +26,6 @@ Package.onUse(function (api) {
     'codegen.js',
     'compiler.js'
   ]);
-
-  // Pull in uglify-js from NPM
-  Npm.depends({
-    'uglify-js': '2.7.5'
-  });
 });
 
 Package.onTest(function (api) {
@@ -47,8 +47,4 @@ Package.onTest(function (api) {
     'compile_tests.js',
     'compiler_output_tests.coffee'
   ]);
-
-  Npm.depends({
-    'uglify-js': '2.7.5'
-  })
 });

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     // boilerplate-generator uses spacebars-compiler.)
     // XXX maybe uglify should be applied by this plugin instead of via magic
     // weak dependency.
-    'minifier-js@1.2.14 || =2.0.0'
+    'minifier-js@1.2.14 || 2.0.0'
   ]);
 
   api.export('TemplatingTools');

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -8,15 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.use([
     'underscore@1.0.9',
-    'ecmascript@0.5.8',
-
-    // minifier-js is a weak dependency of spacebars-compiler; adding it here
-    // ensures that the output is minified.  (Having it as a weak dependency means
-    // that we don't ship uglify etc with built apps just because
-    // boilerplate-generator uses spacebars-compiler.)
-    // XXX maybe uglify should be applied by this plugin instead of via magic
-    // weak dependency.
-    'minifier-js@1.2.14 || 2.0.0'
+    'ecmascript@0.5.8'
   ]);
 
   api.export('TemplatingTools');

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     // boilerplate-generator uses spacebars-compiler.)
     // XXX maybe uglify should be applied by this plugin instead of via magic
     // weak dependency.
-    'minifier-js@1.2.14'
+    'minifier-js@1.2.14 || @2.0.0'
   ]);
 
   api.export('TemplatingTools');

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -16,7 +16,7 @@ Package.onUse(function(api) {
     // boilerplate-generator uses spacebars-compiler.)
     // XXX maybe uglify should be applied by this plugin instead of via magic
     // weak dependency.
-    'minifier-js@1.2.14 || @2.0.0'
+    'minifier-js@1.2.14 || =2.0.0'
   ]);
 
   api.export('TemplatingTools');


### PR DESCRIPTION
Made changes suggested by @abernix and @mitar. Also updated `package.js` for `templating-tools` to accept the new version of `minifier-js`, since the package never uses the API directly.