### PR TITLE
Remove minifier-js version constraints from all .versions files

### DIFF
--- a/packages/blaze-html-templates/.versions
+++ b/packages/blaze-html-templates/.versions
@@ -17,7 +17,6 @@ htmljs@1.0.11
 id-map@1.0.8
 jquery@1.11.9
 meteor@1.6.0
-minifier-js@1.2.14
 modules@0.7.6
 modules-runtime@0.7.6
 mongo-id@1.0.5

--- a/packages/blaze-html-templates/package.js
+++ b/packages/blaze-html-templates/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'blaze-html-templates',
   summary: "Compile HTML templates into reactive UI with Meteor Blaze",
-  version: '1.1.0',
+  version: '1.1.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/blaze-html-templates/package.js
+++ b/packages/blaze-html-templates/package.js
@@ -1,14 +1,14 @@
 Package.describe({
   name: 'blaze-html-templates',
   summary: "Compile HTML templates into reactive UI with Meteor Blaze",
-  version: '1.1.0-1-beta.2',
+  version: '1.1.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
 Package.onUse(function(api) {
   api.imply([
     // A library for reactive user interfaces
-    'blaze@2.3.0-1-beta.2',
+    'blaze@2.3.1',
 
     // The following packages are basically empty shells that just exist to
     // satisfy code checking for the existence of a package. Rest assured that
@@ -17,6 +17,6 @@ Package.onUse(function(api) {
     'spacebars@1.0.13', // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0
 
     // Compile .html files into Blaze reactive views
-    'templating@1.3.0-1-beta.2'
+    'templating@1.3.1'
   ]);
 });

--- a/packages/blaze-html-templates/package.js
+++ b/packages/blaze-html-templates/package.js
@@ -1,14 +1,14 @@
 Package.describe({
   name: 'blaze-html-templates',
   summary: "Compile HTML templates into reactive UI with Meteor Blaze",
-  version: '1.1.0_1',
+  version: '1.1.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
 Package.onUse(function(api) {
   api.imply([
     // A library for reactive user interfaces
-    'blaze@2.3.0',
+    'blaze@2.3.0-1-beta.2',
 
     // The following packages are basically empty shells that just exist to
     // satisfy code checking for the existence of a package. Rest assured that
@@ -17,6 +17,6 @@ Package.onUse(function(api) {
     'spacebars@1.0.13', // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0
 
     // Compile .html files into Blaze reactive views
-    'templating@1.3.0'
+    'templating@1.3.0-1-beta.2'
   ]);
 });

--- a/packages/blaze/.versions
+++ b/packages/blaze/.versions
@@ -27,7 +27,6 @@ jquery@1.11.9
 local-test:blaze@2.3.0
 logging@1.0.14
 meteor@1.6.0
-minifier-js@1.2.14
 minimongo@1.0.17
 modules@0.7.6
 modules-runtime@0.7.6

--- a/packages/blaze/package.js
+++ b/packages/blaze/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'blaze',
   summary: "Meteor Reactive Templating library",
-  version: '2.3.0',
+  version: '2.3.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/blaze/package.js
+++ b/packages/blaze/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'blaze',
   summary: "Meteor Reactive Templating library",
-  version: '2.3.0_1',
+  version: '2.3.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -58,7 +58,7 @@ Package.onTest(function (api) {
   api.use('blaze');
   api.use('blaze-tools@1.0.10'); // for BlazeTools.toJS
   api.use('html-tools@1.0.11');
-  api.use('templating@1.3.0');
+  api.use('templating@1.3.0-1-beta.2');
 
   api.addFiles('view_tests.js');
   api.addFiles('render_tests.js', 'client');

--- a/packages/blaze/package.js
+++ b/packages/blaze/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'blaze',
   summary: "Meteor Reactive Templating library",
-  version: '2.3.0-1-beta.2',
+  version: '2.3.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -58,7 +58,7 @@ Package.onTest(function (api) {
   api.use('blaze');
   api.use('blaze-tools@1.0.10'); // for BlazeTools.toJS
   api.use('html-tools@1.0.11');
-  api.use('templating@1.3.0-1-beta.2');
+  api.use('templating@1.3.1');
 
   api.addFiles('view_tests.js');
   api.addFiles('render_tests.js', 'client');

--- a/packages/caching-html-compiler/.versions
+++ b/packages/caching-html-compiler/.versions
@@ -9,7 +9,6 @@ ecmascript-runtime@0.3.14
 html-tools@1.0.11
 htmljs@1.0.11
 meteor@1.2.17
-minifier-js@1.2.14
 modules@0.7.6
 modules-runtime@0.7.6
 promise@0.8.7

--- a/packages/caching-html-compiler/package.js
+++ b/packages/caching-html-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'caching-html-compiler',
   summary: "Pluggable class for compiling HTML into templates",
-  version: '1.1.0-1-beta.2',
+  version: '1.1.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -15,7 +15,7 @@ Package.onUse(function(api) {
   api.export('CachingHtmlCompiler', 'server');
 
   api.use([
-    'templating-tools@1.1.0-1-beta.2'
+    'templating-tools@1.1.1'
   ]);
 
   api.addFiles([

--- a/packages/caching-html-compiler/package.js
+++ b/packages/caching-html-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'caching-html-compiler',
   summary: "Pluggable class for compiling HTML into templates",
-  version: '1.1.0',
+  version: '1.1.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/caching-html-compiler/package.js
+++ b/packages/caching-html-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'caching-html-compiler',
   summary: "Pluggable class for compiling HTML into templates",
-  version: '1.1.0_1',
+  version: '1.1.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -15,7 +15,7 @@ Package.onUse(function(api) {
   api.export('CachingHtmlCompiler', 'server');
 
   api.use([
-    'templating-tools@1.1.0'
+    'templating-tools@1.1.0-1-beta.2'
   ]);
 
   api.addFiles([

--- a/packages/spacebars-compiler/package.js
+++ b/packages/spacebars-compiler/package.js
@@ -38,7 +38,7 @@ Package.onTest(function (api) {
     'spacebars-compiler',
     'blaze-tools@1.0.10',
     'spacebars@1.0.13',
-    'blaze@2.1.9'
+    'blaze@2.3.0-1-beta.2'
   ]);
 
   api.addFiles([

--- a/packages/spacebars-compiler/package.js
+++ b/packages/spacebars-compiler/package.js
@@ -38,7 +38,7 @@ Package.onTest(function (api) {
     'spacebars-compiler',
     'blaze-tools@1.0.10',
     'spacebars@1.0.13',
-    'blaze@2.3.0-1-beta.2'
+    'blaze@2.3.1'
   ]);
 
   api.addFiles([

--- a/packages/spacebars-tests/.versions
+++ b/packages/spacebars-tests/.versions
@@ -29,7 +29,6 @@ local-test:spacebars-tests@1.1.0
 logging@1.1.15
 markdown@1.0.10
 meteor@1.6.0
-minifier-js@1.2.14
 minimongo@1.0.17
 modules@0.7.6
 modules-runtime@0.7.6

--- a/packages/spacebars-tests/package.js
+++ b/packages/spacebars-tests/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'spacebars-tests',
   summary: "Additional tests for Spacebars",
-  version: '1.1.0-1-beta.2',
+  version: '1.1.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -25,9 +25,9 @@ Package.onTest(function (api) {
 
   api.use([
     'spacebars@1.0.13',
-    'blaze@2.3.0-1-beta.2'
+    'blaze@2.3.1'
   ]);
-  api.use('templating@1.3.0-1-beta.2', 'client');
+  api.use('templating@1.3.1', 'client');
 
   api.addFiles([
     'template_tests.html',

--- a/packages/spacebars-tests/package.js
+++ b/packages/spacebars-tests/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'spacebars-tests',
   summary: "Additional tests for Spacebars",
-  version: '1.1.0',
+  version: '1.1.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/spacebars-tests/package.js
+++ b/packages/spacebars-tests/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'spacebars-tests',
   summary: "Additional tests for Spacebars",
-  version: '1.1.0_1',
+  version: '1.1.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -25,9 +25,9 @@ Package.onTest(function (api) {
 
   api.use([
     'spacebars@1.0.13',
-    'blaze@2.3.0'
+    'blaze@2.3.0-1-beta.2'
   ]);
-  api.use('templating@1.3.0', 'client');
+  api.use('templating@1.3.0-1-beta.2', 'client');
 
   api.addFiles([
     'template_tests.html',

--- a/packages/spacebars/package.js
+++ b/packages/spacebars/package.js
@@ -21,7 +21,7 @@ Package.onUse(function (api) {
   api.export('Spacebars');
 
   api.use('htmljs@1.0.11');
-  api.use('blaze@2.1.9');
+  api.use('blaze@2.3.0-1-beta.2');
 
   api.addFiles([
     'spacebars-runtime.js'

--- a/packages/spacebars/package.js
+++ b/packages/spacebars/package.js
@@ -21,7 +21,7 @@ Package.onUse(function (api) {
   api.export('Spacebars');
 
   api.use('htmljs@1.0.11');
-  api.use('blaze@2.3.0-1-beta.2');
+  api.use('blaze@2.3.1');
 
   api.addFiles([
     'spacebars-runtime.js'

--- a/packages/static-html/.versions
+++ b/packages/static-html/.versions
@@ -9,7 +9,6 @@ ecmascript-runtime@0.3.14
 html-tools@1.0.11
 htmljs@1.0.11
 meteor@1.2.17
-minifier-js@1.2.14
 modules@0.7.6
 modules-runtime@0.7.6
 promise@0.8.7

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'static-html',
   summary: "Define static page content in .html files",
-  version: '1.2.0',
+  version: '1.2.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'static-html',
   summary: "Define static page content in .html files",
-  version: '1.2.0_1',
+  version: '1.2.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -10,8 +10,8 @@ Package.registerBuildPlugin({
   use: [
     'ecmascript@0.5.8',
     'underscore@1.0.9',
-    'caching-html-compiler@1.1.0',
-    'templating-tools@1.1.0'
+    'caching-html-compiler@1.1.0-1-beta.2',
+    'templating-tools@1.1.0-1-beta.2'
   ],
   sources: [
     'static-html.js'

--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'static-html',
   summary: "Define static page content in .html files",
-  version: '1.2.0-1-beta.2',
+  version: '1.2.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -10,8 +10,8 @@ Package.registerBuildPlugin({
   use: [
     'ecmascript@0.5.8',
     'underscore@1.0.9',
-    'caching-html-compiler@1.1.0-1-beta.2',
-    'templating-tools@1.1.0-1-beta.2'
+    'caching-html-compiler@1.1.1',
+    'templating-tools@1.1.1'
   ],
   sources: [
     'static-html.js'

--- a/packages/templating-compiler/.versions
+++ b/packages/templating-compiler/.versions
@@ -9,7 +9,6 @@ ecmascript-runtime@0.3.14
 html-tools@1.0.11
 htmljs@1.0.11
 meteor@1.2.17
-minifier-js@1.2.14
 modules@0.7.6
 modules-runtime@0.7.6
 promise@0.8.7

--- a/packages/templating-compiler/package.js
+++ b/packages/templating-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-compiler',
   summary: "Compile templates in .html files",
-  version: '1.3.0-1-beta.2',
+  version: '1.3.1',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });
@@ -16,8 +16,8 @@ Package.registerBuildPlugin({
   // weak dependency.
   use: [
     'ecmascript@0.5.8',
-    'caching-html-compiler@1.1.0-1-beta.2',
-    'templating-tools@1.1.0-1-beta.2'
+    'caching-html-compiler@1.1.1',
+    'templating-tools@1.1.1'
   ],
   sources: [
     'compile-templates.js'

--- a/packages/templating-compiler/package.js
+++ b/packages/templating-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-compiler',
   summary: "Compile templates in .html files",
-  version: '1.3.0',
+  version: '1.3.0_1',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });

--- a/packages/templating-compiler/package.js
+++ b/packages/templating-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-compiler',
   summary: "Compile templates in .html files",
-  version: '1.3.0_1',
+  version: '1.3.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });
@@ -16,8 +16,8 @@ Package.registerBuildPlugin({
   // weak dependency.
   use: [
     'ecmascript@0.5.8',
-    'caching-html-compiler@1.1.0',
-    'templating-tools@1.1.0'
+    'caching-html-compiler@1.1.0-1-beta.2',
+    'templating-tools@1.1.0-1-beta.2'
   ],
   sources: [
     'compile-templates.js'

--- a/packages/templating-runtime/.versions
+++ b/packages/templating-runtime/.versions
@@ -27,7 +27,6 @@ jquery@1.11.9
 local-test:templating-runtime@1.3.0
 logging@1.0.14
 meteor@1.2.17
-minifier-js@1.2.14
 minimongo@1.0.17
 modules@0.7.6
 modules-runtime@0.7.6

--- a/packages/templating-runtime/package.js
+++ b/packages/templating-runtime/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-runtime',
   summary: "Runtime for compiled .html files",
-  version: '1.3.0-1-beta.2',
+  version: '1.3.1',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });
@@ -20,19 +20,19 @@ Package.onUse(function (api) {
   // Blaze, so anybody using templating (eg apps) need to implicitly use
   // 'meteor' and 'blaze'.
   api.use([
-    'blaze@2.3.0-1-beta.2',
+    'blaze@2.3.1',
     'spacebars@1.0.13'
   ]);
   api.imply([
     'meteor@1.2.17',
-    'blaze@2.3.0-1-beta.2',
+    'blaze@2.3.1',
     'spacebars@1.0.13'
   ], 'client');
 
   // to be able to compile dynamic.html. this compiler is used
   // only inside this package and it should not be implied to not
   // conflict with other packages providing .html compilers.
-  api.use('templating-compiler@1.3.0-1-beta.2');
+  api.use('templating-compiler@1.3.1');
 
   api.addFiles([
     'dynamic.html',
@@ -50,7 +50,7 @@ Package.onTest(function (api) {
 
   api.use([
     'templating-runtime',
-    'templating-compiler@1.3.0-1-beta.2'
+    'templating-compiler@1.3.1'
   ]);
 
   api.addFiles([

--- a/packages/templating-runtime/package.js
+++ b/packages/templating-runtime/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-runtime',
   summary: "Runtime for compiled .html files",
-  version: '1.3.0',
+  version: '1.3.0_1',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });

--- a/packages/templating-runtime/package.js
+++ b/packages/templating-runtime/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-runtime',
   summary: "Runtime for compiled .html files",
-  version: '1.3.0_1',
+  version: '1.3.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git',
   documentation: null
 });
@@ -20,19 +20,19 @@ Package.onUse(function (api) {
   // Blaze, so anybody using templating (eg apps) need to implicitly use
   // 'meteor' and 'blaze'.
   api.use([
-    'blaze@2.1.9',
+    'blaze@2.3.0-1-beta.2',
     'spacebars@1.0.13'
   ]);
   api.imply([
     'meteor@1.2.17',
-    'blaze@2.1.9',
+    'blaze@2.3.0-1-beta.2',
     'spacebars@1.0.13'
   ], 'client');
 
   // to be able to compile dynamic.html. this compiler is used
   // only inside this package and it should not be implied to not
   // conflict with other packages providing .html compilers.
-  api.use('templating-compiler@1.3.0');
+  api.use('templating-compiler@1.3.0-1-beta.2');
 
   api.addFiles([
     'dynamic.html',
@@ -50,7 +50,7 @@ Package.onTest(function (api) {
 
   api.use([
     'templating-runtime',
-    'templating-compiler@1.3.0'
+    'templating-compiler@1.3.0-1-beta.2'
   ]);
 
   api.addFiles([

--- a/packages/templating-tools/.versions
+++ b/packages/templating-tools/.versions
@@ -25,7 +25,6 @@ jquery@1.11.9
 local-test:templating-tools@1.1.0
 logging@1.0.14
 meteor@1.2.17
-minifier-js@1.2.14
 minimongo@1.0.17
 modules@0.7.6
 modules-runtime@0.7.6

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-tools',
   summary: "Tools to scan HTML and compile tags when building a templating package",
-  version: '1.1.0',
+  version: '1.1.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-tools',
   summary: "Tools to scan HTML and compile tags when building a templating package",
-  version: '1.1.0-1-beta.2',
+  version: '1.1.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/templating-tools/package.js
+++ b/packages/templating-tools/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating-tools',
   summary: "Tools to scan HTML and compile tags when building a templating package",
-  version: '1.1.0_1',
+  version: '1.1.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/templating/.versions
+++ b/packages/templating/.versions
@@ -16,7 +16,6 @@ htmljs@1.0.11
 id-map@1.0.8
 jquery@1.11.9
 meteor@1.2.17
-minifier-js@1.2.14
 modules@0.7.6
 modules-runtime@0.7.6
 mongo-id@1.0.5

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating',
   summary: "Allows templates to be defined in .html files",
-  version: '1.3.0',
+  version: '1.3.0_1',
   git: 'https://github.com/meteor/blaze.git'
 });
 

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating',
   summary: "Allows templates to be defined in .html files",
-  version: '1.3.0-1-beta.2',
+  version: '1.3.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -13,8 +13,8 @@ Package.describe({
 Package.onUse(function (api) {
   api.export('Template', 'client');
 
-  api.use('templating-runtime@1.3.0-1-beta.2');
+  api.use('templating-runtime@1.3.1');
   api.imply('templating-runtime');
 
-  api.imply('templating-compiler@1.3.0-1-beta.2');
+  api.imply('templating-compiler@1.3.1');
 });

--- a/packages/templating/package.js
+++ b/packages/templating/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'templating',
   summary: "Allows templates to be defined in .html files",
-  version: '1.3.0_1',
+  version: '1.3.0-1-beta.2',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -13,7 +13,8 @@ Package.describe({
 Package.onUse(function (api) {
   api.export('Template', 'client');
 
-  api.use('templating-runtime@1.3.0');
-  api.imply('templating-compiler@1.3.0');
-  api.imply('templating-runtime@1.3.0');
+  api.use('templating-runtime@1.3.0-1-beta.2');
+  api.imply('templating-runtime');
+
+  api.imply('templating-compiler@1.3.0-1-beta.2');
 });

--- a/packages/ui/package.js
+++ b/packages/ui/package.js
@@ -6,7 +6,7 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use('blaze@2.3.0-1-beta.2');
+  api.use('blaze@2.3.1');
   api.imply('blaze');
 
   // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0.

--- a/packages/ui/package.js
+++ b/packages/ui/package.js
@@ -6,8 +6,8 @@ Package.describe({
 });
 
 Package.onUse(function (api) {
-  api.use('blaze@2.1.9');
-  api.imply('blaze@2.1.9');
+  api.use('blaze@2.3.0-1-beta.2');
+  api.imply('blaze');
 
   // XXX COMPAT WITH PACKAGES BUILT FOR 0.9.0.
   //


### PR DESCRIPTION
In the next 1.4.x.y version of Meteor, the `minifier-js` package is changing to use Babili instead of UglifyJS (https://github.com/meteor/meteor/pull/8397), and we're bumping its version number to 2.0.0 for good measure.

I just published the first beta(s) of Meteor 1.4.3.3 with those changes (`1.4.3.3-beta.1`): https://github.com/meteor/meteor/pull/8439

When I tried creating an app with this beta release, I got the following error:
```sh
% meteor create --release 1.4.3.3-beta.1 1433b1
=> Errors while creating your project         
                                              
While selecting package versions:
error: Conflict: Constraint minifier-js@1.2.14 is not satisfied by minifier-js 2.0.0-beta.1.
Constraints on package "minifier-js":
* minifier-js@2.0.0-beta.1 <- top level
* minifier-js@1.2.14 <- spacebars-compiler 1.1.0 <- boilerplate-generator 1.0.11 <- webapp 1.3.14 <- autoupdate 1.3.12 <- hot-code-push 1.0.4 <- meteor-base 1.0.4
* minifier-js@1.2.14 <- spacebars-compiler 1.1.0 <- boilerplate-generator 1.0.11 <- webapp 1.3.14 <- meteor-base 1.0.4
* minifier-js@1.2.14 <- templating-tools 1.1.0 <- caching-html-compiler 1.1.0 <- templating-compiler 1.3.0 <- templating 1.3.0 <- blaze-html-templates 1.1.0
* minifier-js@1.2.14 <- templating-tools 1.1.0 <- templating-compiler 1.3.0 <- templating 1.3.0 <- blaze-html-templates 1.1.0
* minifier-js@2.0.0-beta.1 <- standard-minifier-js 2.0.0-beta.1
```

Now, as far as I can tell, neither `spacebars-compiler` nor `templating-tools` actually depend on `minifier-js`, but they still have a `minifier-js@1.2.14` constraint in their `.versions` files, which I think is the source of the version conflicts above.

This PR removes any `minifier-js` version constraints from the various `.versions` files in `blaze/packages` and appends a `_1` version suffix to the affected package versions.

I'm submitting this as a pull request just in case it conflicts with any other outstanding work being done (and so that tests will run), though I believe it is safe to merge.

Meteor can proceed with these changes committed locally, but obviously it would be nice to have them merged upstream (or whatever you prefer to do).