### PR TITLE
DOCS: Fix broken internal links

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -89,7 +89,7 @@ Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
 };
 
 /**
- * @summary An inverted [`Blaze.If`](#blaze_if).
+ * @summary An inverted [`Blaze.If`](#Blaze-If).
  * @locus Client
  * @param {Function} conditionFunc A function to reactively re-run.  If the result is falsy, `contentFunc` is shown, otherwise `elseFunc` is shown.  An empty array is considered falsy.
  * @param {Function} contentFunc A Function that returns [*renderable content*](#Renderable-Content).

--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -8,7 +8,7 @@ Blaze._calculateCondition = function (cond) {
  * @summary Constructs a View that renders content with a data context.
  * @locus Client
  * @param {Object|Function} data An object to use as the data context, or a function returning such an object.  If a function is provided, it will be reactively re-run.
- * @param {Function} contentFunc A Function that returns [*renderable content*](#renderable_content).
+ * @param {Function} contentFunc A Function that returns [*renderable content*](#Renderable-Content).
  */
 Blaze.With = function (data, contentFunc) {
   var view = Blaze.View('with', contentFunc);
@@ -54,7 +54,7 @@ Blaze._attachBindingsToView = function (bindings, view) {
  * @summary Constructs a View setting the local lexical scope in the block.
  * @param {Function} bindings Dictionary mapping names of bindings to
  * values or computations to reactively re-run.
- * @param {Function} contentFunc A Function that returns [*renderable content*](#renderable_content).
+ * @param {Function} contentFunc A Function that returns [*renderable content*](#Renderable-Content).
  */
 Blaze.Let = function (bindings, contentFunc) {
   var view = Blaze.View('let', contentFunc);
@@ -67,8 +67,8 @@ Blaze.Let = function (bindings, contentFunc) {
  * @summary Constructs a View that renders content conditionally.
  * @locus Client
  * @param {Function} conditionFunc A function to reactively re-run.  Whether the result is truthy or falsy determines whether `contentFunc` or `elseFunc` is shown.  An empty array is considered falsy.
- * @param {Function} contentFunc A Function that returns [*renderable content*](#renderable_content).
- * @param {Function} [elseFunc] Optional.  A Function that returns [*renderable content*](#renderable_content).  If no `elseFunc` is supplied, no content is shown in the "else" case.
+ * @param {Function} contentFunc A Function that returns [*renderable content*](#Renderable-Content).
+ * @param {Function} [elseFunc] Optional.  A Function that returns [*renderable content*](#Renderable-Content).  If no `elseFunc` is supplied, no content is shown in the "else" case.
  */
 Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
   var conditionVar = new ReactiveVar;
@@ -92,8 +92,8 @@ Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
  * @summary An inverted [`Blaze.If`](#blaze_if).
  * @locus Client
  * @param {Function} conditionFunc A function to reactively re-run.  If the result is falsy, `contentFunc` is shown, otherwise `elseFunc` is shown.  An empty array is considered falsy.
- * @param {Function} contentFunc A Function that returns [*renderable content*](#renderable_content).
- * @param {Function} [elseFunc] Optional.  A Function that returns [*renderable content*](#renderable_content).  If no `elseFunc` is supplied, no content is shown in the "else" case.
+ * @param {Function} contentFunc A Function that returns [*renderable content*](#Renderable-Content).
+ * @param {Function} [elseFunc] Optional.  A Function that returns [*renderable content*](#Renderable-Content).  If no `elseFunc` is supplied, no content is shown in the "else" case.
  */
 Blaze.Unless = function (conditionFunc, contentFunc, elseFunc) {
   return Blaze.If(conditionFunc, contentFunc, elseFunc, true /*_not*/);
@@ -114,9 +114,9 @@ Blaze.Unless = function (conditionFunc, contentFunc, elseFunc) {
  *   object. Inside the Each body, the current item will be set as the data
  *   context.
  * @param {Function} contentFunc A Function that returns  [*renderable
- * content*](#renderable_content).
+ * content*](#Renderable-Content).
  * @param {Function} [elseFunc] A Function that returns [*renderable
- * content*](#renderable_content) to display in the case when there are no items
+ * content*](#Renderable-Content) to display in the case when there are no items
  * in the sequence.
  */
 Blaze.Each = function (argFunc, contentFunc, elseFunc) {

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -11,7 +11,7 @@
  * @summary Constructor for a Template, which is used to construct Views with particular name and content.
  * @locus Client
  * @param {String} [viewName] Optional.  A name for Views constructed by this Template.  See [`view.name`](#view_name).
- * @param {Function} renderFunction A function that returns [*renderable content*](#renderable_content).  This function is used as the `renderFunction` for Views constructed by this Template.
+ * @param {Function} renderFunction A function that returns [*renderable content*](#Renderable-Content).  This function is used as the `renderFunction` for Views constructed by this Template.
  */
 Blaze.Template = function (viewName, renderFunction) {
   if (! (this instanceof Blaze.Template))

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -244,7 +244,7 @@ Blaze.TemplateInstance = function (view) {
    * @name view
    * @memberOf Blaze.TemplateInstance
    * @instance
-   * @summary The [View](#blaze_view) object for this invocation of the template.
+   * @summary The [View](../api/blaze.html#Blaze-View) object for this invocation of the template.
    * @locus Client
    * @type {Blaze.View}
    */
@@ -317,7 +317,7 @@ Blaze.TemplateInstance.prototype.find = function (selector) {
 };
 
 /**
- * @summary A version of [Tracker.autorun](#tracker_autorun) that is stopped when the template is destroyed.
+ * @summary A version of [Tracker.autorun](https://docs.meteor.com/api/tracker.html#Tracker-autorun) that is stopped when the template is destroyed.
  * @locus Client
  * @param {Function} runFunc The function to run. It receives one argument: a Tracker.Computation object.
  */
@@ -326,7 +326,7 @@ Blaze.TemplateInstance.prototype.autorun = function (f) {
 };
 
 /**
- * @summary A version of [Meteor.subscribe](#meteor_subscribe) that is stopped
+ * @summary A version of [Meteor.subscribe](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe) that is stopped
  * when the template is destroyed.
  * @return {SubscriptionHandle} The subscription handle to the newly made
  * subscription. Call `handle.stop()` to manually stop the subscription, or
@@ -339,8 +339,8 @@ Blaze.TemplateInstance.prototype.autorun = function (f) {
  * on server.
  * @param {Function|Object} [options] If a function is passed instead of an
  * object, it is interpreted as an `onReady` callback.
- * @param {Function} [options.onReady] Passed to [`Meteor.subscribe`](#meteor_subscribe).
- * @param {Function} [options.onStop] Passed to [`Meteor.subscribe`](#meteor_subscribe).
+ * @param {Function} [options.onReady] Passed to [`Meteor.subscribe`](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe).
+ * @param {Function} [options.onStop] Passed to [`Meteor.subscribe`](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe).
  * @param {DDP.Connection} [options.connection] The connection on which to make the
  * subscription.
  */
@@ -506,7 +506,7 @@ Template.prototype.events = function (eventMap) {
  * @function
  * @name instance
  * @memberOf Template
- * @summary The [template instance](#template_inst) corresponding to the current template helper, event handler, callback, or autorun.  If there isn't one, `null`.
+ * @summary The [template instance](#Template-instances) corresponding to the current template helper, event handler, callback, or autorun.  If there isn't one, `null`.
  * @locus Client
  * @returns {Blaze.TemplateInstance}
  * @importFromPackage templating
@@ -546,7 +546,7 @@ Template.currentData = Blaze.getData;
 Template.parentData = Blaze._parentData;
 
 /**
- * @summary Defines a [helper function](#template_helpers) which can be used from all templates.
+ * @summary Defines a [helper function](#Template-helpers) which can be used from all templates.
  * @locus Client
  * @function
  * @param {String} name The name of the helper function you are defining.
@@ -556,7 +556,7 @@ Template.parentData = Blaze._parentData;
 Template.registerHelper = Blaze.registerHelper;
 
 /**
- * @summary Removes a global [helper function](#template_helpers).
+ * @summary Removes a global [helper function](#Template-helpers).
  * @locus Client
  * @function
  * @param {String} name The name of the helper function you are defining.

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -38,7 +38,7 @@
  * @summary Constructor for a View, which represents a reactive region of DOM.
  * @locus Client
  * @param {String} [name] Optional.  A name for this type of View.  See [`view.name`](#view_name).
- * @param {Function} renderFunction A function that returns [*renderable content*](#renderable_content).  In this function, `this` is bound to the View.
+ * @param {Function} renderFunction A function that returns [*renderable content*](#Renderable-Content).  In this function, `this` is bound to the View.
  */
 Blaze.View = function (name, render) {
   if (! (this instanceof Blaze.View))

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -599,7 +599,7 @@ var contentAsFunc = function (content) {
 };
 
 /**
- * @summary Renders a template or View to DOM nodes and inserts it into the DOM, returning a rendered [View](#blaze_view) which can be passed to [`Blaze.remove`](#blaze_remove).
+ * @summary Renders a template or View to DOM nodes and inserts it into the DOM, returning a rendered [View](#Blaze-View) which can be passed to [`Blaze.remove`](#Blaze-remove).
  * @locus Client
  * @param {Template|Blaze.View} templateOrView The template (e.g. `Template.myTemplate`) or View object to render.  If a template, a View object is [constructed](#template_constructview).  If a View, it must be an unrendered View, which becomes a rendered View and is returned.
  * @param {DOMNode} parentNode The node that will be the parent of the rendered template.  It must be an Element node.

--- a/packages/templating-runtime/templating.js
+++ b/packages/templating-runtime/templating.js
@@ -40,7 +40,7 @@ Template.__define__ = function (name, renderFunc) {
 // multiple) will have their contents added to it.
 
 /**
- * @summary The [template object](#templates_api) representing your `<body>`
+ * @summary The [template object](#Template-Declarations) representing your `<body>`
  * tag.
  * @locus Client
  */

--- a/site/README.md
+++ b/site/README.md
@@ -6,9 +6,7 @@ This is a [hexo](https://hexo.io) static site used to generate the [Blaze JS Doc
 
 #### Submodules
 
-This repo has two submodules, one the theme, the other full Meteor repository.
-
-We have the Meteor repo to generate the `data.js` file (see below).
+This repo has two submodules, one the theme, the other a test runner.
 
 After cloning, or updating the repo, it makes sense to run
 
@@ -20,7 +18,7 @@ Generally you should not commit changes to the submodules, unless you know what 
 
 #### Generating `data.js`
 
-To generate the api boxes, the site uses a file `data/data.js` which is generated from the js docs in the [Meteor source code](https://github.com/meteor/meteor). This will automatically happen whenever you start your local hexo server.
+To generate the api boxes, the site uses a file `data/data.js` which is generated from the js docs in the [Blaze source code](https://github.com/meteor/blaze). This will automatically happen whenever you start your local hexo server.
 
 #### Starting hexo
 

--- a/site/scripts/api-box.js
+++ b/site/scripts/api-box.js
@@ -174,25 +174,25 @@ var toOrSentence = function (array) {
 
 var typeNameTranslation = {
   "function": "Function",
-  EJSON: typeLink("EJSON-able Object", "#ejson"),
-  EJSONable: typeLink("EJSON-able Object", "#ejson"),
-  "Tracker.Computation": typeLink("Tracker.Computation", "#tracker_computation"),
+  EJSON: typeLink("EJSON-able Object", "https://docs.meteor.com/api/ejson.html"),
+  EJSONable: typeLink("EJSON-able Object", "https://docs.meteor.com/api/ejson.html"),
+  "Tracker.Computation": typeLink("Tracker.Computation", "https://docs.meteor.com/api/tracker.html#tracker_computation"),
   MongoSelector: [
-    typeLink("Mongo Selector", "#selectors"),
-    typeLink("Object ID", "#mongo_object_id"),
+    typeLink("Mongo Selector", "https://docs.meteor.com/api/collections.html#selectors"),
+    typeLink("Object ID", "https://docs.meteor.com/api/collections.html#Mongo-ObjectID"),
     "String"
   ],
-  MongoModifier: typeLink("Mongo Modifier", "#modifiers"),
-  MongoSortSpecifier: typeLink("Mongo Sort Specifier", "#sortspecifiers"),
-  MongoFieldSpecifier: typeLink("Mongo Field Specifier", "#fieldspecifiers"),
+  MongoModifier: typeLink("Mongo Modifier", "https://docs.meteor.com/api/collections.html#modifiers"),
+  MongoSortSpecifier: typeLink("Mongo Sort Specifier", "https://docs.meteor.com/api/collections.html#sortspecifiers"),
+  MongoFieldSpecifier: typeLink("Mongo Field Specifier", "https://docs.meteor.com/api/collections.html#fieldspecifiers"),
   JSONCompatible: "JSON-compatible Object",
-  EventMap: typeLink("Event Map", "#eventmaps"),
+  EventMap: typeLink("Event Map", "#Event-Maps"),
   DOMNode: typeLink("DOM Node", "https://developer.mozilla.org/en-US/docs/Web/API/Node"),
-  "Blaze.View": typeLink("Blaze.View", "#blaze_view"),
-  Template: typeLink("Blaze.Template", "#blaze_template"),
+  "Blaze.View": typeLink("Blaze.View", "#Blaze-View"),
+  Template: typeLink("Blaze.Template", "#Blaze-Template"),
   DOMElement: typeLink("DOM Element", "https://developer.mozilla.org/en-US/docs/Web/API/element"),
-  MatchPattern: typeLink("Match Pattern", "#matchpatterns"),
-  "DDP.Connection": typeLink("DDP Connection", "#ddp_connect")
+  MatchPattern: typeLink("Match Pattern", "https://docs.meteor.com/api/check.html#matchpatterns"),
+  "DDP.Connection": typeLink("DDP Connection", "https://docs.meteor.com/api/connections.html#DDP-connect")
 };
 
 handlebars.registerHelper('typeNames', function typeNames (nameList) {

--- a/site/source/api/blaze.md
+++ b/site/source/api/blaze.md
@@ -80,10 +80,10 @@ way to understand and customize Meteor's rendering behavior for more
 advanced applications and packages.
 
 You can obtain a View object by calling [`Blaze.render`](#Blaze-render) on a
-template, or by accessing [`template.view`](../api/templates.html#template-view) on a template
+template, or by accessing [`template.view`](../api/templates.html#Blaze-TemplateInstance-view) on a template
 instance.
 
-At the heart of a View is an [autorun](#tracker_autorun) that calls the View's
+At the heart of a View is an [autorun](https://docs.meteor.com/api/tracker.html#Tracker-autorun) that calls the View's
 `renderFunction`, uses the result to create DOM nodes, and replaces the
 contents of the View with these new DOM nodes.  A View's content may consist
 of any number of consecutive DOM nodes (though if it is zero, a placeholder
@@ -149,9 +149,9 @@ by Meteor have names like "Template.foo" and "if".
 {% enddtdd %}
 
 {% dtdd name:"autorun(runFunc)" id:"view_autorun" %}
-  Like [`Tracker.autorun`](#tracker_autorun), except that the autorun is
+  Like [`Tracker.autorun`](https://docs.meteor.com/api/tracker.html#Tracker-autorun), except that the autorun is
   automatically stopped when the View is destroyed, and the
-  [current View](#blaze_currentview) is always set when running `runFunc`.
+  [current View](#Blaze-currentView) is always set when running `runFunc`.
   There is no relationship to the View's internal autorun or render
   cycle.  In `runFunc`, the View is bound to `this`.
 {% enddtdd %}
@@ -160,19 +160,19 @@ by Meteor have names like "Template.foo" and "if".
   If the View hasn't been created yet, calls `func` when the View
   is created.  In `func`, the View is bound to `this`.
 
-  This hook is the basis for the [`created`](#template_created)
+  This hook is the basis for the [`created`](../api/templates.html#Template-onCreated)
   template callback.
 {% enddtdd %}
 
 {% dtdd name:"onViewReady(func)" id:"view_onviewready" %}
   Calls `func` when the View is rendered and inserted into the DOM,
   after waiting for the end of
-  [flush time](#tracker_afterflush).  Does not fire if the View
+  [flush time](https://docs.meteor.com/api/tracker.html#Tracker-afterFlush).  Does not fire if the View
   is destroyed at any point before it would fire.
   May fire multiple times (if the View re-renders).
   In `func`, the View is bound to `this`.
 
-  This hook is the basis for the [`rendered`](#template_rendered)
+  This hook is the basis for the [`rendered`](../api/templates.html#Template-onRendered)
   template callback.
 {% enddtdd %}
 
@@ -181,7 +181,7 @@ by Meteor have names like "Template.foo" and "if".
   View is destroyed.  A View may be destroyed without ever becoming
   "ready."  In `func`, the View is bound to `this`.
 
-  This hook is the basis for the [`destroyed`](#template_destroyed)
+  This hook is the basis for the [`destroyed`](../api/templates.html#Template-onDestroyed)
   template callback.
 {% enddtdd %}
 
@@ -207,8 +207,8 @@ object.  For example, `Blaze.render(Template.foo).template === Template.foo`.
 
 {% dtdd name:"templateInstance()" type:"Template instance" id:"view_templateinstance" %}
 For Views created by invoking templates,
-returns the [template instance](#template_inst) object for this
-particular View.  For example, in a [`created`](#template_created)
+returns the [template instance](../api/templates.html#Template-instances) object for this
+particular View.  For example, in a [`created`](../api/templates.html#Template-onCreated)
 callback, `this.view.templateInstance() === this`.
 
 Template instance objects have fields like `data`, `firstNode`, and

--- a/site/source/api/templates.md
+++ b/site/source/api/templates.md
@@ -116,7 +116,7 @@ Template.myPictures.onRendered(function () {
 
 Callbacks added with this method are called before your template's logic is
 evaluated for the first time. Inside a callback, `this` is the new [template
-instance](#template_inst) object. Properties you set on this object will be
+instance](#Template-instances) object. Properties you set on this object will be
 visible from the callbacks added with `onRendered` and `onDestroyed` methods and
 from event handlers.
 
@@ -360,7 +360,7 @@ comma-separated list.
 
 The handler function receives two arguments: `event`, an object with
 information about the event, and `template`, a [template
-instance](#template_inst) for the template where the handler is
+instance](#Template-instances) for the template where the handler is
 defined.  The handler also receives some additional context data in
 `this`, depending on the context of the current element handling the
 event.  In a template, an element's context is the

--- a/site/source/api/templates.md
+++ b/site/source/api/templates.md
@@ -81,13 +81,13 @@ Callbacks added with this method are called once when an instance of
 Template.*myTemplate* is rendered into DOM nodes and put into the document for
 the first time.
 
-In the body of a callback, `this` is a [template instance](../api/templates.html#Template-instance)
+In the body of a callback, `this` is a [template instance](../api/templates.html#Template-instances)
 object that is unique to this occurrence of the template and persists across
 re-renderings. Use the `onCreated` and `onDestroyed` callbacks to perform
 initialization or clean-up on the object.
 
 Because your template has been rendered, you can use functions like
-[`this.findAll`](../api/templates.html#Template-findAll) which look at its DOM nodes.
+[`this.findAll`](../api/templates.html#Blaze-TemplateInstance-findAll) which look at its DOM nodes.
 
 This can be a good place to apply any DOM manipulations you want, after the
 template is rendered for the first time.
@@ -138,7 +138,7 @@ Template.myPictures.onCreated(function () {
 
 These callbacks are called when an occurrence of a template is taken off
 the page for any reason and not replaced with a re-rendering.  Inside
-a callback, `this` is the [template instance](../api/templates.html#Template-instance) object
+a callback, `this` is the [template instance](../api/templates.html#Template-instances) object
 being destroyed.
 
 This group of callbacks is most useful for cleaning up or undoing any external
@@ -316,7 +316,7 @@ any `Template.myTemplate` object.
 
 Helpers on `Template.body` are only available in the `<body>` tags of
 your app.  To register a global helper, use
-[Template.registerHelper](../api/templates.html#Template-registerhelper).
+[Template.registerHelper](../api/templates.html#Template-registerHelper).
 Event maps on `Template.body` don't apply to elements added to the
 body via `Blaze.render`, jQuery, or the DOM API, or to the body element
 itself.  To handle events on the body, window, or document, use jQuery

--- a/site/source/guide/reusable-components.md
+++ b/site/source/guide/reusable-components.md
@@ -163,7 +163,7 @@ When you are setting up event maps in your JS files, you need to 'select' the el
 
 ## Passing HTML content as a template argument
 
-If you need to pass in content to a sub-component (for instance the content of a modal dialog), you can use the [custom block helper](../guide/spacebars.html#block-helpers) to provide a block of content. If you need more flexibility, typically just providing the component name as an argument is the way to go. The sub-component can then just render that component with:
+If you need to pass in content to a sub-component (for instance the content of a modal dialog), you can use the [custom block helper](../guide/spacebars.html#Block-Helpers) to provide a block of content. If you need more flexibility, typically just providing the component name as an argument is the way to go. The sub-component can then just render that component with:
 
 ```html
 {{> Template.dynamic templateName dataContext}}


### PR DESCRIPTION
I found several broken links in the Blaze docs with incorrect capitalisation or 
change from `_` to `-` and relative links to Meteor docs. I've edited links in 
JSDOC blocks and in `site` where I found issues.

Not sure how to rebuild the docs, so haven't tested a full build.