### PR TITLE
Remove version constraints from spacebars-compiler test dependencies.

### DIFF
--- a/packages/spacebars-compiler/package.js
+++ b/packages/spacebars-compiler/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'spacebars-compiler',
   summary: "Compiler for Spacebars template language",
-  version: '1.1.2',
+  version: '1.1.3',
   git: 'https://github.com/meteor/blaze.git'
 });
 
@@ -29,14 +29,11 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use([
-    'underscore@1.0.9',
-    'tinytest@1.0.11',
-    'coffeescript@1.2.4'
-  ]);
-
-  api.use([
+    'underscore',
+    'tinytest',
+    'coffeescript',
     'spacebars-compiler',
-    'blaze-tools@1.0.10'
+    'blaze-tools'
   ]);
 
   api.addFiles([


### PR DESCRIPTION
These version constraints are unnecessary, since `./meteor test-packages` runs from a checkout, and all of the depended-on packages can be found in `meteor/packages`, `meteor/packages/non-core`, or `meteor/packages/non-core/blaze/packages`.

This should fix the problem noted by @GeoffreyBooth in this [comment](https://github.com/meteor/meteor/pull/8960#issuecomment-319726289).