### PR TITLE
spacebars-compiler optimisations

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ checkout:
     - git submodule update --init --recursive
 machine:
   node:
-    version: 0.12
+    version: 8
   pre:
     - git config --global user.name "circleci"
     - git config --global user.email "circleci@users.noreply.github.com"
@@ -22,7 +22,7 @@ test:
     #    parallel: true
     - METEOR_COMMAND=/tmp/meteor/meteor tests/test-runner/test-all.sh:
         parallel: true
-    - cd site; npm run generate
+    - cd site; npm run build
 deployment:
   s3:
     branch: /^(master|version-.*)/

--- a/packages/htmljs/visitors.js
+++ b/packages/htmljs/visitors.js
@@ -110,7 +110,22 @@ HTML.TransformingVisitor.def({
   visitComment: IDENTITY,
   visitCharRef: IDENTITY,
   visitRaw: IDENTITY,
-  visitObject: IDENTITY,
+  visitObject: function(obj/*, ...*/){
+    // Don't parse Markdown & RCData as HTML
+    if (obj.textMode != null){
+      return obj;
+    }
+    var argsCopy = SLICE.call(arguments);
+    if ('content' in obj) {
+      argsCopy[0] = obj.content;
+      obj.content = this.visit.apply(this, argsCopy);
+    }
+    if ('elseContent' in obj){
+      argsCopy[0] = obj.elseContent;
+      obj.elseContent = this.visit.apply(this, argsCopy);
+    }
+    return obj;
+  },
   visitFunction: IDENTITY,
   visitTag: function (tag/*, ...*/) {
     var oldChildren = tag.children;

--- a/packages/spacebars-compiler/compiler_output_tests.coffee
+++ b/packages/spacebars-compiler/compiler_output_tests.coffee
@@ -310,3 +310,13 @@ function() {
     });
   }
   """
+
+  run "<div><div>{{helper}}<div>a</div><div>b</div></div></div>",
+  """
+function() {
+  var view = this;
+  return HTML.DIV(HTML.DIV(Blaze.View("lookup:helper",function(){
+      return Spacebars.mustache(view.lookup("helper"));
+  }), HTML.Raw("<div>a</div><div>b</div>")));
+}
+  """

--- a/packages/spacebars-compiler/compiler_output_tests.coffee
+++ b/packages/spacebars-compiler/compiler_output_tests.coffee
@@ -320,3 +320,14 @@ function() {
   }), HTML.Raw("<div>a</div><div>b</div>")));
 }
   """
+
+  run "<table><colgroup><col></colgroup><tr><td>aaa</td><td>bbb</td></tr></table>",
+  """
+function() {
+  var view = this;
+  return HTML.TABLE(
+    HTML.Raw("<colgroup><col></colgroup>"),
+    HTML.TR(HTML.Raw("<td>aaa</td><td>bbb</td>"))
+  );
+}
+  """

--- a/packages/spacebars-compiler/compiler_output_tests.coffee
+++ b/packages/spacebars-compiler/compiler_output_tests.coffee
@@ -126,6 +126,22 @@ function() {
 }
   """
 
+  run "{{!-- --}}{{#if cond}}<p>aaa</p><p>ppp</p>{{!\n}}{{else}}{{!}}<p>{{bbb}}</p>{{!-- --}}{{/if}}{{!}}",
+  """
+function() {
+  var view = this;
+  return Blaze.If(function () {
+    return Spacebars.call(view.lookup("cond"));
+  }, (function() {
+    return HTML.Raw("<p>aaa</p><p>ppp</p>");
+  }), (function() {
+    return HTML.P(Blaze.View("lookup:bbb", function() {
+      return Spacebars.mustache(view.lookup("bbb"));
+    }));
+  }));
+}
+  """
+
   run "{{> foo bar}}",
   """
   function() {

--- a/packages/spacebars-compiler/optimizer.js
+++ b/packages/spacebars-compiler/optimizer.js
@@ -160,7 +160,7 @@ RawCompactingVisitor.def({
             result[result.length - 1].value + item.value);
         }
       } else {
-        result.push(item);
+        result.push(this.visit(item));
       }
     }
     return result;

--- a/packages/spacebars-compiler/optimizer.js
+++ b/packages/spacebars-compiler/optimizer.js
@@ -55,7 +55,9 @@ CanOptimizeVisitor.def({
       // browser will insert a TBODY.  If we just `createElement("table")` and
       // `createElement("tr")`, on the other hand, no TBODY is necessary
       // (assuming IE 8+).
-      return OPTIMIZABLE.NONE;
+      return OPTIMIZABLE.PARTS;
+    } else if (tagName === 'tr'){
+      return OPTIMIZABLE.PARTS;
     }
 
     var children = tag.children;

--- a/packages/spacebars-compiler/templatetag.js
+++ b/packages/spacebars-compiler/templatetag.js
@@ -401,6 +401,7 @@ TemplateTag.parseCompleteTag = function (scannerOrString, position) {
         shouldStop: isAtBlockCloseOrElse,
         textMode: textMode
       };
+    result.textMode = textMode;
     result.content = HTMLTools.parseFragment(scanner, parserOptions);
 
     if (scanner.rest().slice(0, 2) !== '{{')
@@ -420,6 +421,7 @@ TemplateTag.parseCompleteTag = function (scannerOrString, position) {
         lastElseContentTag.elseContent.type = 'BLOCKOPEN';
         lastElseContentTag.elseContent.path = tmplTag.path;
         lastElseContentTag.elseContent.args = tmplTag.args;
+        lastElseContentTag.elseContent.textMode = textMode;
         lastElseContentTag.elseContent.content = HTMLTools.parseFragment(scanner, parserOptions);
 
         lastElseContentTag = lastElseContentTag.elseContent;

--- a/site/package.json
+++ b/site/package.json
@@ -3,34 +3,32 @@
   "version": "0.0.0",
   "private": true,
   "hexo": {
-    "version": "3.2.2"
+    "version": "3.5.0"
   },
   "dependencies": {
     "canonical-json": "0.0.4",
-    "handlebars": "^4.0.5",
-    "hexo": "^3.1.0",
-    "hexo-generator-archive": "^0.1.2",
-    "hexo-generator-category": "^0.1.2",
-    "hexo-generator-index": "^0.1.2",
-    "hexo-generator-tag": "^0.1.1",
-    "hexo-renderer-ejs": "^0.1.0",
-    "hexo-renderer-less": "^0.1.3",
-    "hexo-renderer-marked": "^0.2.4",
-    "hexo-renderer-stylus": "^0.3.0",
-    "hexo-server": "^0.1.2",
-    "jsdoc": "git+https://github.com/meteor/jsdoc.git#espree-3.1",
-    "showdown": "^1.3.0",
-    "underscore": "^1.8.3"
+    "handlebars": "4.0.11",
+    "hexo": "3.5.0",
+    "hexo-generator-archive": "0.1.5",
+    "hexo-generator-category": "0.1.3",
+    "hexo-generator-index": "0.2.1",
+    "hexo-generator-tag": "0.2.0",
+    "hexo-renderer-ejs": "0.3.1",
+    "hexo-renderer-less": "0.2.0",
+    "hexo-renderer-marked": "0.3.2",
+    "hexo-renderer-stylus": "0.3.3",
+    "hexo-server": "0.3.1",
+    "jsdoc": "3.5.5",
+    "showdown": "1.8.6",
+    "underscore": "1.8.3"
   },
-  "devDependencies": {
-    "hexo-s3-deploy": "meteor/hexo-s3-deploy#e36f6d046660040878bb5bedfc8422f526a78be6"
-  },
+  "devDependencies": {},
   "scripts": {
-    "prestart": "jsdoc/jsdoc.sh",
-    "start": "hexo server",
-    "predeploy": "jsdoc/jsdoc.sh",
-    "deploy": "hexo-s3-deploy",
-    "pregenerate": "jsdoc/jsdoc.sh",
-    "generate": "hexo generate"
+    "build": "jsdoc/jsdoc.sh && hexo generate",
+    "clean": "hexo clean; rm data/data.js data/names.json",
+    "test": "npm run clean; npm run build",
+    "predeploy": "npm run build",
+    "deploy": "exit 1",
+    "start": "npm run build && hexo server"
   }
 }


### PR DESCRIPTION
Hi,

Found a few instances where the spacebars compiler aborts optimisations unnecessarily.

Case 1: Inside Block tags, eg `{{#if }} ... {{else}} ... {{/if}}`
Case 2: More than one level of nested elements.  (Compacting `HTML.Raw` fails)
Case 3: Inside `<tables>` (caused by a pessimistic workaround to auto-injection of `<tbody>` when using `innerHTML`.)

The resolution for Case 1 turned out messier than I had hoped. Due to block tags like `{{#markdown}}` that don't contain HTML. Rather than exposing the `textMode` prop, maybe something like `isHTML`?


----

My motivation for digging through this code, is to implement a `<template whitespace="strip">` mode [1]. Which would work similar to react (Strip any whitespace that contains a newline).

Early comparisons show that this saves around ~100kb (uncompressed) from my client bundle.

[1] https://github.com/3stack-software/blaze/commit/de3d4215e29d71bd973814398c223e57acab19da