### PR TITLE
Make Template._currentTemplateInstanceFunc read-only when possible.

### DIFF
--- a/packages/blaze/package.js
+++ b/packages/blaze/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'blaze',
   summary: "Meteor Reactive Templating library",
-  version: '2.3.2',
+  version: '2.3.3',
   git: 'https://github.com/meteor/blaze.git'
 });
 


### PR DESCRIPTION
By defining `Template._currentTemplateInstanceFunc` using a getter function (without a corresponding setter function), we can make it effectively read-only, which should prevent any outside tampering.

Besides being a reasonable safety measure, this change also appears to fix a bizarre JSC (Safari) bug that can make `Template.instance()` return `null`: https://github.com/meteor/meteor/issues/9926#issuecomment-406464957