### PR TITLE
Add back raw/endraw to tags {{ name }} and {{ score }} in intro docs

### DIFF
--- a/site/source/index.md
+++ b/site/source/index.md
@@ -51,7 +51,7 @@ Here are two Spacebars templates from an example app called "Leaderboard" which 
 </template>
 ```
 
-The template tags `{{name}}` and `{{score}}` refer to properties of the data context (the current player), while `players` and `selected` refer to helper functions.  Helper functions and event handlers are defined in JavaScript:
+The template tags `{% raw %}{{name}}{% endraw %} ` and `{% raw %}{{score}}{% endraw %} ` refer to properties of the data context (the current player), while `players` and `selected` refer to helper functions.  Helper functions and event handlers are defined in JavaScript:
 
 
 ```javascript


### PR DESCRIPTION
The tags `{{name}}` and `{{score}}` are not properly rendered on http://blazejs.org/ homepage.
I think this is related to a previous PR #135