### PR TITLE
Remove underscore from static-html

### DIFF
--- a/packages/static-html/package.js
+++ b/packages/static-html/package.js
@@ -1,15 +1,14 @@
 Package.describe({
   name: 'static-html',
   summary: "Define static page content in .html files",
-  version: '1.3.0',
+  version: '1.3.1',
   git: 'https://github.com/meteor/blaze.git'
 });
 
 Package.registerBuildPlugin({
   name: "compileStaticHtmlBatch",
   use: [
-    'ecmascript@0.14.4',
-    'underscore@1.0.9',
+    'ecmascript@0.15.1',
     'caching-html-compiler@1.2.0',
     'templating-tools@1.2.0'
   ],

--- a/packages/static-html/static-html.js
+++ b/packages/static-html/static-html.js
@@ -16,6 +16,8 @@ function compileTagsToStaticHtml(tags) {
   return handler.getResults();
 };
 
+var isEmpty = obj => [Object, Array].includes((obj || {}).constructor) && !Object.entries((obj || {})).length;
+
 class StaticHtmlTagHandler {
   constructor() {
     this.results = {
@@ -34,7 +36,7 @@ class StaticHtmlTagHandler {
     this.tag = tag;
 
     // do we have 1 or more attributes?
-    const hasAttribs = ! _.isEmpty(this.tag.attribs);
+    const hasAttribs = ! isEmpty(this.tag.attribs);
 
     if (this.tag.tagName === "head") {
       if (hasAttribs) {


### PR DESCRIPTION
Remove underscore from `static-html`, there is no need to get the entire package for just one function that can be easily replaced: https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore#_isempty