### PR TITLE
Faster fragment parsing

### DIFF
--- a/packages/blaze/dombackend.js
+++ b/packages/blaze/dombackend.js
@@ -11,7 +11,6 @@ DOMBackend._$jq = $jq;
 
 
 DOMBackend.getContext = function() {
-  return document;
   if (DOMBackend._context) {
     return DOMBackend._context;
   }

--- a/packages/blaze/dombackend.js
+++ b/packages/blaze/dombackend.js
@@ -9,13 +9,33 @@ if (! $jq)
 
 DOMBackend._$jq = $jq;
 
+
+DOMBackend.getContext = function() {
+  return document;
+  if (DOMBackend._context) {
+    return DOMBackend._context;
+  }
+  if ( DOMBackend._$jq.support.createHTMLDocument ) {
+    DOMBackend._context = document.implementation.createHTMLDocument( "" );
+
+    // Set the base href for the created document
+    // so any parsed elements with URLs
+    // are based on the document's URL (gh-2965)
+    const base = DOMBackend._context.createElement( "base" );
+    base.href = document.location.href;
+    DOMBackend._context.head.appendChild( base );
+  } else {
+    DOMBackend._context = document;
+  }
+  return DOMBackend._context;
+}
 DOMBackend.parseHTML = function (html) {
   // Return an array of nodes.
   //
   // jQuery does fancy stuff like creating an appropriate
   // container element and setting innerHTML on it, as well
   // as working around various IE quirks.
-  return $jq.parseHTML(html) || [];
+  return $jq.parseHTML(html, DOMBackend.getContext()) || [];
 };
 
 DOMBackend.Events = {


### PR DESCRIPTION
Happy to see Blaze getting some Love - I've been using this change in production for a good long while, figured it was maybe time to merge.

Whenever you render raw HTML in `{{{}}}` and whenever you render any static HTML that has no `{{}}` in it (e.g., `<li>Test</li>`) ` jquery's `parseHTML` is called, which generates a new document context. This causes some pieces of jquery to try and figure out the compatibility (IE/ Safari quirks, etc) of the current document EVERY time an element like this is rendered. 

I'm 99% sure we could just return `document` from `DOMBackend.getContext` - but this is "more correct". The code is taken from `jq.parseHTML`

I'm wondering if anyone can see any issues with this? Possibly if rendering into an iframe?