### PR TITLE
Eliminate whitespace in Template.dynamic

### DIFF
--- a/packages/templating-runtime/dynamic.html
+++ b/packages/templating-runtime/dynamic.html
@@ -3,21 +3,21 @@ the template to render) and an optional `data` property. If the `data`
 property is not specified, then the parent data context will be used
 instead. Uses the __dynamicWithDataContext template below to actually
 render the template. -->
-<template name="__dynamic">
-  {{checkContext}}
-  {{#if dataContextPresent}}
-    {{# __dynamicWithDataContext}}{{> Template.contentBlock}}{{/__dynamicWithDataContext}}
-  {{else}}
-    {{! if there was no explicit 'data' argument, use the parent context}}
-    {{# __dynamicWithDataContext template=template data=..}}{{> Template.contentBlock}}{{/__dynamicWithDataContext}}
-  {{/if}}
-</template>
+<template name="__dynamic">{{
+  checkContext}}{{
+  #if dataContextPresent}}{{
+    # __dynamicWithDataContext}}{{> Template.contentBlock}}{{/__dynamicWithDataContext}}{{
+  else
+    }}{{! if there was no explicit 'data' argument, use the parent context}}{{
+    # __dynamicWithDataContext template=template data=..}}{{> Template.contentBlock}}{{/__dynamicWithDataContext}}{{
+  /if
+}}</template>
 
 <!-- Expects the data context to have a `template` property (the name of
 the template to render) and a `data` property, which can be falsey. -->
-<template name="__dynamicWithDataContext">
-  {{#with chooseTemplate template}}
-    {{!-- The .. is evaluated inside {{#with ../data}} --}}
-    {{# .. ../data}}{{> Template.contentBlock}}{{/ ..}}
-  {{/with}}
-</template>
+<template name="__dynamicWithDataContext">{{
+  #with chooseTemplate template
+    }}{{!-- The .. is evaluated inside {{#with ../data}} --}}{{
+    # .. ../data}}{{> Template.contentBlock}}{{/ ..}}{{
+  /with
+}}</template>


### PR DESCRIPTION
By moving the whitespace from between the handlebars to inside them, six newlines are eliminated from each instantiation of Template.dynamic.. This is important for cases where you need to have no whitespace between the dynamic template content and the surrounding tags.