### PR TITLE
Fixing current module when previous module is undefined in blaze-hot

### DIFF
--- a/packages/blaze-hot/hot.js
+++ b/packages/blaze-hot/hot.js
@@ -134,7 +134,8 @@ if (module.hot) {
           });
         });
       }
-      currentModule = previousModule
+      // for example, main.html doesn't have a previous module
+      currentModule = previousModule || {id: null};
     }
   });
 }


### PR DESCRIPTION
- This happens for main.html for example.

Fixes #354