### PR TITLE
Remove duplicate key

### DIFF
--- a/packages/blaze/attrs.js
+++ b/packages/blaze/attrs.js
@@ -243,7 +243,6 @@ var isUrlAttribute = function (tagName, attrName) {
     A: ['href'],
     AREA: ['href'],
     LINK: ['href'],
-    BASE: ['href'],
     IMG: ['longdesc', 'src', 'usemap'],
     FRAME: ['longdesc', 'src'],
     IFRAME: ['longdesc', 'src'],


### PR DESCRIPTION
`Base` is defined twice with the same value.