### PR TITLE
Remove underscore from observe sequence

### DIFF
--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -260,7 +260,7 @@ const diffArray = function (lastSeqArray, seqArray, callbacks) {
       if (before) {
         // If not adding at the end, we need to update indexes.
         // XXX this can still be improved greatly!
-        posCur.forEach(function (pos, id) {
+        Object.entries(posCur).forEach(function ([id, pos]) {
           if (pos >= position)
             posCur[id]++;
         });
@@ -303,7 +303,7 @@ const diffArray = function (lastSeqArray, seqArray, callbacks) {
       //   2. The element is moved back. Then the positions in between *and* the
       //   element that is currently standing on the moved element's future
       //   position are moved forward.
-      posCur.forEach(function (elCurPosition, id) {
+      Object.entries(posCur).forEach(function ([id, elCurPosition]) {
         if (oldPosition < elCurPosition && elCurPosition < newPosition)
           posCur[id]--;
         else if (newPosition <= elCurPosition && elCurPosition < oldPosition)
@@ -323,7 +323,7 @@ const diffArray = function (lastSeqArray, seqArray, callbacks) {
     removed: function (id) {
       var prevPosition = posCur[idStringify(id)];
 
-      posCur.forEach(function (pos, id) {
+      Object.entries(posCur).forEach(function ([id, pos]) {
         if (pos >= prevPosition)
           posCur[id]--;
       });
@@ -337,9 +337,11 @@ const diffArray = function (lastSeqArray, seqArray, callbacks) {
         prevPosition);
     }
   });
+  
+  Object.entries(posNew).forEach(function ([idString, pos]) {
 
-  posNew.forEach(function (pos, idString) {
     var id = idParse(idString);
+    
     if (has(posOld, idString)) {
       // specifically for primitive types, compare equality before
       // firing the 'changedAt' callback. otherwise, always fire it

--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -1,5 +1,16 @@
-const isObject = Npm.require('lodash.isobject');
-const has = Npm.require('lodash.has');
+const isObject = function (value) {
+  var type = typeof value;
+  return value != null && (type == 'object' || type == 'function');
+}
+const has = function (obj, key) {
+  var keyParts = key.split('.');
+
+  return !!obj && (
+    keyParts.length > 1
+      ? has(obj[key.split('.')[0]], keyParts.slice(1).join('.'))
+      : hasOwnProperty.call(obj, key)
+  );
+};
 
 const warn = function () {
   if (ObserveSequence._suppressWarnings) {

--- a/packages/observe-sequence/observe_sequence.js
+++ b/packages/observe-sequence/observe_sequence.js
@@ -1,5 +1,5 @@
-import isObject from 'lodash.isobject';
-import has from 'lodash.has';
+const isObject = Npm.require('lodash.isobject');
+const has = Npm.require('lodash.has');
 
 const warn = function () {
   if (ObserveSequence._suppressWarnings) {

--- a/packages/observe-sequence/observe_sequence_tests.js
+++ b/packages/observe-sequence/observe_sequence_tests.js
@@ -48,7 +48,7 @@ runOneObserveSequenceTestCase = function (test, sequenceFunc,
     removedAt: function (...args) {
       firedCallbacks.push({removedAt: args});
     },
-    movedTo: function () {
+    movedTo: function (...args) {
       firedCallbacks.push({movedTo: args});
     }
   });
@@ -678,7 +678,7 @@ Tinytest.add('observe-sequence - vm generated number arrays', function (test) {
 });
 
 Tinytest.add('observe-sequence - number arrays, _id:0 correctly handled, no duplicate ids warning #4049', function (test) {
-  var seq = [...Array(2).keys()].map(function (i) { return { _id: i}; });
+  var seq = [...Array(3).keys()].map(function (i) { return { _id: i}; });
   var dep = new Tracker.Dependency;
 
   runOneObserveSequenceTestCase(test, function () {

--- a/packages/observe-sequence/observe_sequence_tests.js
+++ b/packages/observe-sequence/observe_sequence_tests.js
@@ -20,11 +20,11 @@ runOneObserveSequenceTestCase = function (test, sequenceFunc,
 
   var firedCallbacks = [];
   var handle = ObserveSequence.observe(sequenceFunc, {
-    addedAt: function () {
-      firedCallbacks.push({addedAt: _.toArray(arguments)});
+    addedAt: function (...args) {
+      firedCallbacks.push({addedAt: args});
     },
-    changedAt: function () {
-      var obj = {changedAt: _.toArray(arguments)};
+    changedAt: function (...args) {
+      var obj = {changedAt: args};
 
       // Browsers are inconsistent about the order in which 'changedAt'
       // callbacks fire. To ensure consistent behavior of these tests,
@@ -45,11 +45,11 @@ runOneObserveSequenceTestCase = function (test, sequenceFunc,
 
       firedCallbacks.splice(i, 0, obj);
     },
-    removedAt: function () {
-      firedCallbacks.push({removedAt: _.toArray(arguments)});
+    removedAt: function (...args) {
+      firedCallbacks.push({removedAt: args});
     },
     movedTo: function () {
-      firedCallbacks.push({movedTo: _.toArray(arguments)});
+      firedCallbacks.push({movedTo: args});
     }
   });
 
@@ -69,11 +69,11 @@ runOneObserveSequenceTestCase = function (test, sequenceFunc,
   var commonLength = Math.min(firedCallbacks.length, expectedCallbacks.length);
   for (var i = 0; i < commonLength; i++) {
     var callback = expectedCallbacks[i];
-    if (_.keys(callback).length !== 1)
+    if (Object.keys(callback).length !== 1)
       throw new Error("Callbacks should be objects with one key, eg `addedAt`");
-    var callbackName = _.keys(callback)[0];
-    var args = _.values(callback)[0];
-    _.each(args, function (arg, argIndex) {
+    var callbackName = Object.keys(callback)[0];
+    var args = Object.values(callback)[0];
+    args.forEach(function (arg, argIndex) {
       if (arg && typeof arg === 'object' &&
           'NOT' in arg &&
           firedCallbacks[i][callbackName]) {
@@ -544,7 +544,7 @@ Tinytest.add('observe-sequence - cursor to other cursor', function (test) {
 Tinytest.add('observe-sequence - cursor to other cursor with transform', function (test) {
   var dep = new Tracker.Dependency;
   var transform = function(doc) {
-    return _.extend({idCopy: doc._id}, doc);
+    return Object.assign({idCopy: doc._id}, doc);
   };
 
   var coll = new Mongo.Collection(null, {transform: transform});
@@ -678,7 +678,7 @@ Tinytest.add('observe-sequence - vm generated number arrays', function (test) {
 });
 
 Tinytest.add('observe-sequence - number arrays, _id:0 correctly handled, no duplicate ids warning #4049', function (test) {
-  var seq = _.map(_.range(3), function (i) { return { _id: i}; });
+  var seq = [...Array(2).keys()].map(function (i) { return { _id: i}; });
   var dep = new Tracker.Dependency;
 
   runOneObserveSequenceTestCase(test, function () {
@@ -689,7 +689,7 @@ Tinytest.add('observe-sequence - number arrays, _id:0 correctly handled, no dupl
     // _id. An expression like `(item && item._id) || index` would incorrectly
     // return '2' for the last item because the _id is falsy (although it is not
     // undefined, but 0!).
-    seq = _.map([1, 2, 0], function (i) { return { _id: i}; });
+    seq = [1, 2, 0].map(function (i) { return { _id: i}; });
     dep.changed();
   }, [
     {addedAt: [0, {_id: 0}, 0, null]},

--- a/packages/observe-sequence/package.js
+++ b/packages/observe-sequence/package.js
@@ -4,7 +4,7 @@ Package.describe({
 });
 
 Npm.depends({
-  "lodash.isobject": "^3.0.2",
+  "lodash.isobject": "3.0.2",
   "lodash.has": "4.5.2"
 })
 

--- a/packages/observe-sequence/package.js
+++ b/packages/observe-sequence/package.js
@@ -3,11 +3,15 @@ Package.describe({
   version: "1.0.19"
 });
 
+Npm.depends({
+  "lodash.isobject": "^3.0.2",
+  "lodash.has": "4.5.2"
+})
+
 Package.onUse(function (api) {
   api.use('tracker@1.2.0');
   api.use('mongo-id@1.0.8');  // for idStringify
   api.use('diff-sequence@1.1.1');
-  api.use('underscore@1.0.10');
   api.use('random@1.2.0');
   api.export('ObserveSequence');
   api.addFiles(['observe_sequence.js']);
@@ -17,7 +21,6 @@ Package.onTest(function (api) {
   api.use([
     'tinytest',
     'observe-sequence',
-    'underscore',
     'ejson',
     'tracker',
     'mongo'

--- a/packages/observe-sequence/package.js
+++ b/packages/observe-sequence/package.js
@@ -3,11 +3,6 @@ Package.describe({
   version: "1.0.19"
 });
 
-Npm.depends({
-  "lodash.isobject": "3.0.2",
-  "lodash.has": "4.5.2"
-})
-
 Package.onUse(function (api) {
   api.use('tracker@1.2.0');
   api.use('mongo-id@1.0.8');  // for idStringify


### PR DESCRIPTION
As I'm wrapping up https://github.com/meteor/meteor/pull/11869 [Test Group 3](https://app.circleci.com/pipelines/github/meteor/meteor/2782/workflows/150e8e89-1d4d-4bbd-b448-e05355b496c4/jobs/77335) is failing because it runs non-core packages and observe-sequence [requires underscore](https://github.com/meteor/blaze/blob/master/packages/observe-sequence/package.js#L20) which is no longer around since now it's now deprecated. There's no need for publishing a new version of Blaze or Observer-sequence; this PR just needs to be merged in dev branch so in meteor repo the latest commit can pulled. Coincidentally, I'm glad the the underscore removal was done here first as it'd not have worked if it had been done in Meteor repo first. :sweat_smile:  