### PR TITLE
Prevent firing callbacks until members are destroyed

### DIFF
--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -489,14 +489,19 @@ Blaze._destroyView = function (view, _skipNodes) {
     return;
   view.isDestroyed = true;
 
-  Blaze._fireCallbacks(view, 'destroyed');
 
   // Destroy views and elements recursively.  If _skipNodes,
   // only recurse up to views, not elements, for the case where
   // the backend (jQuery) is recursing over the elements already.
 
-  if (view._domrange)
-    view._domrange.destroyMembers(_skipNodes);
+  if (view._domrange) view._domrange.destroyMembers(_skipNodes);
+
+  // XXX: fire callbacks after potential members are destroyed
+  // otherwise it's tracker.flush will cause the above line will
+  // not be called and their views won't be destroyed
+  // Involved issues: DOMRange "Must be attached" error, mem leak
+  
+  Blaze._fireCallbacks(view, 'destroyed');
 };
 
 Blaze._destroyNode = function (node) {


### PR DESCRIPTION
I found a few errors related to #213 (cc @lynchem) when I moved to a new route and a new template is drawn.

I debugged my Templates and found that child templates of the page I "left" were not destroyed, while the page main template was destroyed correctly and the child template was also in `_domrange.members`.

So I started a deeper debugging session and found that `Blaze._fireCallbacks(view, 'destroyed')` was placed before `view._domrange.destroyMembers` and prevented the members from being removed, because the whole method just aborted after `_fireCallbacks` was called.

Placing it after them removes the members and the errors are gone, while at least our app tests are running fine.

I can't say if this is related to the errors in #213 but I can say that this was definitely a memory leak.
I also don't know where I should place tests for this to prevent future regressions (especially if we do a lot of rewrites for 3.0). Please help whoever can.


