### PR TITLE
Remove fibers from codebase

### DIFF
--- a/packages/spacebars-tests/template_tests_server.js
+++ b/packages/spacebars-tests/template_tests_server.js
@@ -17,18 +17,18 @@ Meteor.publish("templateSub", function (futureId) {
       // `makeTemplateSubReady` without introducing an async/wait cascade
       // Thus we link it to a member of the promise and store it in the dict.
       // This is the same effect as the prior Future.wait() approach.
-      let resolver
+      let resolver;
       const promise = new Promise((resolve) => {
-        resolver = resolve
-      })
-      promise.return = () => resolver()
+        resolver = resolve;
+      });
+      promise.return = () => resolver();
 
-      templateSubFutures[futureId] = promise
-      await templateSubFutures[futureId]
-      delete templateSubFutures[futureId]
+      templateSubFutures[futureId] = promise;
+      await templateSubFutures[futureId];
+      delete templateSubFutures[futureId];
     }
 
-    self.ready()
+    self.ready();
   });
 });
 Meteor.methods({

--- a/packages/spacebars-tests/template_tests_server.js
+++ b/packages/spacebars-tests/template_tests_server.js
@@ -1,5 +1,4 @@
-var path = Npm.require("path");
-var Future = Npm.require('fibers/future');
+const path = Npm.require("path");
 
 Meteor.methods({
   getAsset: function (filename) {
@@ -7,18 +6,29 @@ Meteor.methods({
   }
 });
 
-var templateSubFutures = {};
+const templateSubFutures = {};
+
 Meteor.publish("templateSub", function (futureId) {
-  var self = this;
-  Meteor.defer(function () {  // because subs are blocking
+  const self = this;
+  Meteor.defer(async function () {  // because subs are blocking
     if (futureId) {
-      var f = new Future();
-      templateSubFutures[futureId] = f;
-      f.wait();
-      delete templateSubFutures[futureId];
+      // XXX: this looks a little bit weird but we need to make
+      // the internal `resolve` of the promise accessible for the Meteor.method
+      // `makeTemplateSubReady` without introducing an async/wait cascade
+      // Thus we link it to a member of the promise and store it in the dict.
+      // This is the same effect as the prior Future.wait() approach.
+      let resolver
+      const promise = new Promise((resolve) => {
+        resolver = resolve
+      })
+      promise.return = () => resolver()
+
+      templateSubFutures[futureId] = promise
+      await templateSubFutures[futureId]
+      delete templateSubFutures[futureId]
     }
 
-    self.ready();
+    self.ready()
   });
 });
 Meteor.methods({


### PR DESCRIPTION
This PR removes the `fibers/future` package and replaces the test code with an `async/await` counterpart.