### PR TITLE
Add linter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,29 @@ $ meteor npm run setup # create link to packages
 
 This has to be done only once.
 
+#### Run the linter
+
+We use eslint with the [quave config](https://github.com/quavedev/eslint-config), which is also used
+by the Meteor core project.
+
+Due to the fact, that this repo consists of multiple packages, you should run the linter for single packages
+like so:
+
+```bash
+$ cd test-app
+$ meteor npm run lint:check -- ./packages/templating-compiler 
+```
+
+If you need to lint other packages, use `.packages/<nameOfPackage>` or use `./packages/` to lint all packages.
+Beware, however, that this might take a while to lint all packages.
+
+The same goes for autofixing common lint errors:
+
+```bash
+$ cd test-app
+$ meteor npm run lint:check -- ./packages/templating-compiler
+```
+
 #### Run the tests
 
 Simply execute the test script:

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -8,6 +8,8 @@
   "scripts": {
     "start": "meteor run",
     "setup": "ln -sfn ../packages ./packages",
+    "lint:check": "npx eslint",
+    "lint:fix": "npm run eslint --fix",
     "test:watch": "meteor test-packages --raw-logs ./packages/*",
     "test:ci": "ci.sh"
   },
@@ -17,5 +19,13 @@
     "jquery": "^3.6.0",
     "meteor-node-stubs": "^1.2.1",
     "puppeteer": "^10.4.0"
+  },
+  "devDependencies": {
+    "@quave/eslint-config-quave": "^1.0.7"
+  },
+  "eslintConfig": {
+    "extends": [
+      "@quave/quave"
+    ]
   }
 }


### PR DESCRIPTION
As discussed in #337 as well as in #367 we use the quave config now.

I also did not yet added the lint check to the CI config because I think this should not be done before the respective packages are not moved to es6 and pass the linter.

Once a package is moved to es6 and passes the linter we can add it to the CI each step by step.

To lint a single package use in the test app

```bash
$ cd test-app
$ meteor npm run lint:check -- ./packages/templating-compiler 
```

(The example only lints `templating-compiler`)

or use 

```bash
$ meteor npm run lint:check -- ./packages/
```

To lint all packages. Same goes with the fix `lint:fix` script.

