### PR TITLE
Move package caching-html-compiler to ES6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,10 @@
 * [#374](https://github.com/meteor/blaze/pull/374) `Blaze.remove` should destroy view before detaching
 * [#376](https://github.com/meteor/blaze/pull/376) Modify 'Must be attached' error to be more descriptive
 * [#377](https://github.com/meteor/blaze/pull/377) Add tests for [Blaze.remove should destroy view before detaching](https://github.com/meteor/blaze/pull/374)
+* [#382](https://github.com/meteor/blaze/pull/382) Linters were added
+* [#348](https://github.com/meteor/blaze/pull/348) For-in loop does not work in IE fix
+* [#349](https://github.com/meteor/blaze/pull/349) fix regression: non array iterables were always treated as empty
+* [#341](https://github.com/meteor/blaze/pull/341) add support for arbitrary iterables in #each templates
 
 ## v2.6.0, 2022-April-13
 

--- a/packages/caching-html-compiler/package.js
+++ b/packages/caching-html-compiler/package.js
@@ -1,27 +1,24 @@
+/* eslint-env meteor */
 Package.describe({
   name: 'caching-html-compiler',
-  summary: "Pluggable class for compiling HTML into templates",
+  summary: 'Pluggable class for compiling HTML into templates',
   version: '1.2.1',
-  git: 'https://github.com/meteor/blaze.git'
+  git: 'https://github.com/meteor/blaze.git',
 });
 
 Npm.depends({
-  'lodash.isempty': '4.4.0'
+  'lodash.isempty': '4.4.0',
 });
 
 Package.onUse(function(api) {
   api.use([
     'caching-compiler@1.2.2',
-    'ecmascript@0.15.1'
+    'ecmascript@0.15.1',
   ]);
 
   api.export('CachingHtmlCompiler', 'server');
 
-  api.use([
-    'templating-tools@1.2.1'
-  ]);
+  api.use(['templating-tools@1.2.1']);
 
-  api.addFiles([
-    'caching-html-compiler.js'
-  ], 'server');
+  api.addFiles(['caching-html-compiler.js'], 'server');
 });


### PR DESCRIPTION
There are a few things that the linter really does not like but we can't really change them without breaking lots of things, for example using global namespace or having class methods that never use `this` (but since they derive from CachingCompiler we can't make them static).