### PR TITLE
Stop establishing unnecessary reactive dependencies

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -530,13 +530,13 @@ Template.prototype.events = function (eventMap) {
     eventMap2[k] = (function (k, v) {
       return function (event /*, ...*/) {
         var view = this; // passed by EventAugmenter
+        var args = Array.prototype.slice.call(arguments);
         // Exiting the current computation to avoid creating unnecessary
         // and unexpected reactive dependencies with Templates data
         // or any other reactive dependencies defined in event handlers
         return Tracker.nonreactive(function () {
           var data = Blaze.getData(event.currentTarget);
           if (data == null) data = {};
-          var args = Array.prototype.slice.call(arguments);
           var tmplInstanceFunc = Blaze._bind(view.templateInstance, view);
           args.splice(1, 0, tmplInstanceFunc());
           return Template._withTemplateInstanceFunc(tmplInstanceFunc, function () {

--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -530,14 +530,18 @@ Template.prototype.events = function (eventMap) {
     eventMap2[k] = (function (k, v) {
       return function (event /*, ...*/) {
         var view = this; // passed by EventAugmenter
-        var data = Blaze.getData(event.currentTarget);
-        if (data == null) data = {};
-        var args = Array.prototype.slice.call(arguments);
-        var tmplInstanceFunc = Blaze._bind(view.templateInstance, view);
-        args.splice(1, 0, tmplInstanceFunc());
-
-        return Template._withTemplateInstanceFunc(tmplInstanceFunc, function () {
-          return v.apply(data, args);
+        // Exiting the current computation to avoid creating unnecessary
+        // and unexpected reactive dependencies with Templates data
+        // or any other reactive dependencies defined in event handlers
+        return Tracker.nonreactive(function () {
+          var data = Blaze.getData(event.currentTarget);
+          if (data == null) data = {};
+          var args = Array.prototype.slice.call(arguments);
+          var tmplInstanceFunc = Blaze._bind(view.templateInstance, view);
+          args.splice(1, 0, tmplInstanceFunc());
+          return Template._withTemplateInstanceFunc(tmplInstanceFunc, function () {
+            return v.apply(data, args);
+          });
         });
       };
     })(k, eventMap[k]);


### PR DESCRIPTION
The problem I have faced in my current Meteor project is clearly demonstrated in this simple example project: https://github.com/imajus/blaze-reactive-loop-example

While this doesn't cause visible issues in most cases, in some cases, like the one presented in this repository, it can lead to unexpected and hard-to-track issues. Additionally, it adds unnecessary overhead to the reactive computation system, which may result in unnecessary re-rendering.

**Proposed solution**

Since the behavior in question is definitely not intended and potentially harmful, I believe the best approach would be to prevent event handlers from establishing new reactive dependencies if they are called from any reactive computation.

