### PR TITLE
Tests for ensuring that event handlers are not reactive

### DIFF
--- a/packages/spacebars-tests/templating_tests.html
+++ b/packages/spacebars-tests/templating_tests.html
@@ -83,6 +83,14 @@
 </div>
 </template>
 
+<template name="test_event_reactive_loop_parent">
+  <div>{{>test_event_reactive_loop_child childData}}</div>
+</template>
+
+<template name="test_event_reactive_loop_child">
+  <div>I must not cause a dependency loop</div>
+</template>
+
 <template name="test_capture_events">
   <video class='video1'>
     <source id='mp4'


### PR DESCRIPTION
This is a new automated test case to reproduce the scenario I've earlier presented with [this](https://github.com/imajus/blaze-reactive-loop-example) example project and then submitted a [PR#406](https://github.com/meteor/blaze/pull/406) to fix it.

Now, when I know how to work with the Blaze automated testing system I could migrate the scenario to the Blaze repository and seal it as a behavior expectation for the future builds.

Note: The test is expected to fail on a current state of the source code but will pass once the aforementioned PR is merged.