### PR TITLE
Fix for legacy client

### DIFF
--- a/packages/observe-sequence/package.js
+++ b/packages/observe-sequence/package.js
@@ -8,6 +8,7 @@ Package.onUse(function (api) {
   api.use('mongo-id@1.0.8');  // for idStringify
   api.use('diff-sequence@1.1.1');
   api.use('random@1.2.0');
+  api.use('ecmascript@0.13.2');
   api.export('ObserveSequence');
   api.addFiles(['observe_sequence.js']);
 });

--- a/packages/templating-tools/code-generation.js
+++ b/packages/templating-tools/code-generation.js
@@ -8,7 +8,7 @@ export function generateTemplateJS(name, renderFuncCode, useHMR) {
     return `
 Template._migrateTemplate(
   ${nameLiteral},
-  new Template(${templateDotNameLiteral}, ${renderFuncCode}),
+  new Template(${templateDotNameLiteral}, ${renderFuncCode})
 );
 if (typeof module === "object" && module.hot) {
   module.hot.accept();


### PR DESCRIPTION
- Compiles observe-sequence with ecmascript so it can use new syntax.
- Fixes the code generated in development when HMR is enabled so it doesn't cause syntax errors in old browsers.