### PR TITLE
Implemented async bindings in `#let`.

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -32,22 +32,41 @@ Blaze.With = function (data, contentFunc) {
   return view;
 };
 
+
+/**
+ * @summary Shallow compare of two bindings.
+ * @param {Binding} x
+ * @param {Binding} y
+ */
+function _isEqualBinding(x, y) {
+  return x && y ? x.error === y.error && x.value === y.value : x === y;
+}
+
 /**
  * Attaches bindings to the instantiated view.
  * @param {Object} bindings A dictionary of bindings, each binding name
  * corresponds to a value or a function that will be reactively re-run.
- * @param {View} view The target.
+ * @param {Blaze.View} view The target.
  */
 Blaze._attachBindingsToView = function (bindings, view) {
+  function setBindingValue(name, value) {
+    if (value instanceof Promise) {
+      value.then(
+        value => view._scopeBindings[name].set({ value }),
+        error => view._scopeBindings[name].set({ error }),
+      );
+    } else {
+      view._scopeBindings[name].set({ value });
+    }
+  }
+
   view.onViewCreated(function () {
     Object.entries(bindings).forEach(function ([name, binding]) {
-      view._scopeBindings[name] = new ReactiveVar();
+      view._scopeBindings[name] = new ReactiveVar(undefined, _isEqualBinding);
       if (typeof binding === 'function') {
-        view.autorun(function () {
-          view._scopeBindings[name].set(binding());
-        }, view.parentView);
+        view.autorun(() => setBindingValue(name, binding()), view.parentView);
       } else {
-        view._scopeBindings[name].set(binding);
+        setBindingValue(name, binding);
       }
     });
   });
@@ -149,7 +168,7 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
 
     for (var i = from; i <= to; i++) {
       var view = eachView._domrange.members[i].view;
-      view._scopeBindings['@index'].set(i);
+      view._scopeBindings['@index'].set({ value: i });
     }
   };
 
@@ -240,7 +259,7 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
               itemView = eachView.initialSubviews[index];
             }
             if (eachView.variableName) {
-              itemView._scopeBindings[eachView.variableName].set(newItem);
+              itemView._scopeBindings[eachView.variableName].set({ value: newItem });
             } else {
               itemView.dataVar.set(newItem);
             }

--- a/packages/blaze/lookup.js
+++ b/packages/blaze/lookup.js
@@ -13,8 +13,14 @@ function _createBindingsHelper(fn) {
       ? Object.keys(view._scopeBindings)
       : names.slice(0, -1);
 
-    // TODO: What should happen if there's no such binding?
-    return names.some(name => fn(_lexicalBindingLookup(view, name).get()));
+    return names.some(name => {
+      const binding = _lexicalBindingLookup(view, name);
+      if (!binding) {
+        throw new Error(`Binding for "${name}" was not found.`);
+      }
+
+      return fn(binding.get());
+    });
   };
 }
 

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -34,6 +34,14 @@
 /// Views associated with templates have names of the form "Template.foo".
 
 /**
+ * A binding is either `undefined` (pending), `{ error }` (rejected), or
+ * `{ value }` (resolved). Synchronous values are immediately resolved (i.e.,
+ * `{ value }` is used). The other states are reserved for asynchronous bindings
+ * (i.e., values wrapped with `Promise`s).
+ * @typedef {{ error: unknown } | { value: unknown } | undefined} Binding
+ */
+
+/**
  * @class
  * @summary Constructor for a View, which represents a reactive region of DOM.
  * @locus Client
@@ -81,6 +89,7 @@ Blaze.View = function (name, render) {
   this._hasGeneratedParent = false;
   // Bindings accessible to children views (via view.lookup('name')) within the
   // closest template view.
+  /** @type {Record<string, ReactiveVar<Binding>>} */
   this._scopeBindings = {};
 
   this.renderCount = 0;

--- a/packages/spacebars-tests/async_tests.html
+++ b/packages/spacebars-tests/async_tests.html
@@ -1,0 +1,69 @@
+<template name="spacebars_async_tests_access">
+  {{#let a=x.y}}{{a}}{{/let}}
+</template>
+
+<template name="spacebars_async_tests_direct">
+  {{#let a=x}}{{a}}{{/let}}
+</template>
+
+<template name="spacebars_async_tests_missing1">
+  {{@pending 'b'}}
+</template>
+
+<template name="spacebars_async_tests_missing2">
+  {{#let a=1}}{{@pending 'b'}}{{/let}}
+</template>
+
+<template name="spacebars_async_tests_state1">
+  {{#let a=x}}
+    {{#if @pending}}1{{/if}}
+    {{#if @rejected}}2{{/if}}
+    {{#if @resolved}}3{{/if}}
+
+    {{#if @pending 'a'}}a1{{/if}}
+    {{#if @rejected 'a'}}a2{{/if}}
+    {{#if @resolved 'a'}}a3{{/if}}
+  {{/let}}
+</template>
+
+<template name="spacebars_async_tests_state2flat">
+  {{#let a=x b=y}}
+    {{#if @pending}}1{{/if}}
+    {{#if @rejected}}2{{/if}}
+    {{#if @resolved}}3{{/if}}
+
+    {{#if @pending 'a'}}a1{{/if}}
+    {{#if @rejected 'a'}}a2{{/if}}
+    {{#if @resolved 'a'}}a3{{/if}}
+
+    {{#if @pending 'b'}}b1{{/if}}
+    {{#if @rejected 'b'}}b2{{/if}}
+    {{#if @resolved 'b'}}b3{{/if}}
+
+    {{#if @pending 'a' 'b'}}ab1{{/if}}
+    {{#if @rejected 'a' 'b'}}ab2{{/if}}
+    {{#if @resolved 'a' 'b'}}ab3{{/if}}
+  {{/let}}
+</template>
+
+<template name="spacebars_async_tests_state2nested">
+  {{#let a=x}}
+    {{#let b=y}}
+      {{#if @pending}}1{{/if}}
+      {{#if @rejected}}2{{/if}}
+      {{#if @resolved}}3{{/if}}
+
+      {{#if @pending 'a'}}a1{{/if}}
+      {{#if @rejected 'a'}}a2{{/if}}
+      {{#if @resolved 'a'}}a3{{/if}}
+
+      {{#if @pending 'b'}}b1{{/if}}
+      {{#if @rejected 'b'}}b2{{/if}}
+      {{#if @resolved 'b'}}b3{{/if}}
+
+      {{#if @pending 'a' 'b'}}ab1{{/if}}
+      {{#if @rejected 'a' 'b'}}ab2{{/if}}
+      {{#if @resolved 'a' 'b'}}ab3{{/if}}
+    {{/let}}
+  {{/let}}
+</template>

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -1,0 +1,80 @@
+function asyncTest(templateName, testName, fn) {
+  Tinytest.addAsync(`spacebars-tests - async - ${templateName} ${testName}`, test => {
+    const template = Blaze.Template[`spacebars_async_tests_${templateName}`];
+    const templateCopy = new Blaze.Template(template.viewName, template.renderFunction);
+    return fn(test, templateCopy, () => {
+      const div = renderToDiv(templateCopy);
+      return () => canonicalizeHtml(div.innerHTML);
+    });
+  });
+}
+
+function asyncSuite(templateName, cases) {
+  for (const [testName, helpers, before, after] of cases) {
+    asyncTest(templateName, testName, async (test, template, render) => {
+      template.helpers(helpers);
+      const readHTML = render();
+      test.equal(readHTML(), before);
+      await new Promise(Tracker.afterFlush);
+      test.equal(readHTML(), after);
+    });
+  }
+}
+
+asyncSuite('access', [
+  ['getter', { x: { y: async () => 'foo' } }, '', 'foo'],
+  ['value', { x: { y: Promise.resolve('foo') } }, '', 'foo'],
+]);
+
+asyncSuite('direct', [
+  ['getter', { x: async () => 'foo' }, '', 'foo'],
+  ['value', { x: Promise.resolve('foo') }, '', 'foo'],
+]);
+
+asyncTest('missing1', 'outer', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  test.throws(render, 'Binding for "b" was not found.');
+});
+
+asyncTest('missing2', 'inner', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  test.throws(render, 'Binding for "b" was not found.');
+});
+
+// In the following tests pending=1, rejected=2, resolved=3.
+const pending = new Promise(() => {});
+const rejected = Promise.reject();
+const resolved = Promise.resolve();
+
+// Ignore unhandled rejection error.
+rejected.catch(() => {});
+
+asyncSuite('state1', [
+  ['pending', { x: pending }, '1 a1', '1 a1'],
+  ['rejected', { x: rejected }, '1 a1', '2 a2'],
+  ['resolved', { x: resolved }, '1 a1', '3 a3'],
+]);
+
+asyncSuite('state2flat', [
+  ['pending pending', { x: pending, y: pending }, '1 a1 b1 ab1', '1 a1 b1 ab1'],
+  ['pending rejected', { x: pending, y: rejected }, '1 a1 b1 ab1', '1 2 a1 b2 ab1 ab2'],
+  ['pending resolved', { x: pending, y: resolved }, '1 a1 b1 ab1', '1 3 a1 b3 ab1 ab3'],
+  ['rejected pending', { x: rejected, y: pending }, '1 a1 b1 ab1', '1 2 a2 b1 ab1 ab2'],
+  ['rejected rejected', { x: rejected, y: rejected }, '1 a1 b1 ab1', '2 a2 b2 ab2'],
+  ['rejected resolved', { x: rejected, y: resolved }, '1 a1 b1 ab1', '2 3 a2 b3 ab2 ab3'],
+  ['resolved pending', { x: resolved, y: pending }, '1 a1 b1 ab1', '1 3 a3 b1 ab1 ab3'],
+  ['resolved rejected', { x: resolved, y: rejected }, '1 a1 b1 ab1', '2 3 a3 b2 ab2 ab3'],
+  ['resolved resolved', { x: resolved, y: resolved }, '1 a1 b1 ab1', '3 a3 b3 ab3'],
+]);
+
+asyncSuite('state2nested', [
+  ['pending pending', { x: pending, y: pending }, '1 a1 b1 ab1', '1 a1 b1 ab1'],
+  ['pending rejected', { x: pending, y: rejected }, '1 a1 b1 ab1', '2 a1 b2 ab1 ab2'],
+  ['pending resolved', { x: pending, y: resolved }, '1 a1 b1 ab1', '3 a1 b3 ab1 ab3'],
+  ['rejected pending', { x: rejected, y: pending }, '1 a1 b1 ab1', '1 a2 b1 ab1 ab2'],
+  ['rejected rejected', { x: rejected, y: rejected }, '1 a1 b1 ab1', '2 a2 b2 ab2'],
+  ['rejected resolved', { x: rejected, y: resolved }, '1 a1 b1 ab1', '3 a2 b3 ab2 ab3'],
+  ['resolved pending', { x: resolved, y: pending }, '1 a1 b1 ab1', '1 a3 b1 ab1 ab3'],
+  ['resolved rejected', { x: resolved, y: rejected }, '1 a1 b1 ab1', '2 a3 b2 ab2 ab3'],
+  ['resolved resolved', { x: resolved, y: resolved }, '1 a1 b1 ab1', '3 a3 b3 ab3'],
+]);

--- a/packages/spacebars-tests/package.js
+++ b/packages/spacebars-tests/package.js
@@ -29,6 +29,8 @@ Package.onTest(function (api) {
   api.use('templating@1.4.1', 'client');
 
   api.addFiles([
+    'async_tests.html',
+    'async_tests.js',
     'template_tests.html',
     'template_tests.js',
     'templating_tests.html',


### PR DESCRIPTION
In this pull request, I made `#let` handle `Promise`s. It supersedes #409 as it solves the same problem, but there's no `#letAwait` needed.

### How it works

All Blaze `View`s store a binding mapping (`_scopeBindings`), where `#each` stores the `@index` variable and `#let` stores the locally scoped variables. Each binding is not a value but rather a `ReactiveVar` that is updated when needed.

In this PR, these `ReactiveVar`s no longer store the _value_ but rather a `Binding` object. Type-wise, it's either `undefined` (pending), `{ error }` (rejected), or `{ value }` (resolved). Synchronous values are immediately resolved (i.e., `{ value }` is used). The other states are reserved for asynchronous bindings (i.e., values wrapped with `Promise`s).

That means the following template:
```html
<template name="example">
  {{#let name=getName}}
    Hi, {{name}}!
  {{/let}}
</template>
```

Works with both synchronous and asynchronous `getName`:

```ts
Template.example.helpers({
  // Synchronous value.
  getName: 'John',

  // Asynchronous value.
  getName: Promise.resolve('John'),

  // Synchronous helper.
  getName: () => 'John',

  // Asynchronous helper.
  getName: async () => 'John',
});
```

### Async state

As the unwrapping of `Promise`s is not synchronous, all asynchronous values and helpers will start in a pending state. In such cases, the resolved value is always `undefined`. That means the template above will show `Hi, !` at first for both asynchronous examples. Similarly, a rejection will make the value `undefined`.

But there are cases where we'd like to know whether the operation is still pending or if it failed. To make it possible, there are three new global helpers:
* `@pending`, which checks whether any of the given bindings is still pending.
* `@rejected`, which checks whether any of the given bindings has rejected.
* `@resolved`, which checks whether any of the given bindings has resolved.

The usage looks as follows:

```html
<template name="example">
  {{#let name=getName}}
    {{#if @pending 'name'}}
      We are fetching your name...
    {{/if}}
    {{#if @rejected 'name'}}
      Sorry, an error occured!
    {{/if}}
    {{#if @resolved 'name'}}
      Hi, {{name}}!
    {{/if}}
  {{/let}}
</template>
```

All of them accept a list of names to check. Passing no arguments is the same as passing all bindings from the inner-most `#let`:

```html
<template name="example">
  {{#let name=getName}}
    {{#let greeting=getGreeting}}
      {{#if @pending}}
        We are fetching your greeting...
      {{/if}}
      {{#if @rejected 'name'}}
        Sorry, an error occurred while fetching your name!
      {{/if}}
      {{#if @resolved 'greeting' 'name'}}
        {{greeting}}, {{name}}!
      {{/if}}
    {{/let}}
  {{/let}}
</template>
```

Given the following helpers:

```ts
Template.example.helpers({
  getGreeting: new Promise(resolve => setTimeout(() => resolve('Hi'), 2000)),
  getName: new Promise(resolve => setTimeout(() => resolve('John'), 1000)),
});
```

We'll see three states:
* "We are fetching your greeting..."
* "We are fetching your greeting..." and ", John!"
* "Hi, John!"

### Backward compatibility

As long as you never returned `Promise`s from your helpers used in `#let` blocks, everything should work as before. If you did, these will be unwrapped. Note that direct usage of asynchronous helpers (e.g., `{{counterAsync}}`) won't work and will render `[object Promise]` instead.

### TODO

* [x] Decide whether `@pending`/`@rejected`/`@resolved` should check for _any_ or _all_ bindings.
    * We've decided to leave it as _any_ for now, document this behavior, and mark it as a subject it change.
* [x] Decide what level of synchronisation is needed for bindings. Right now there’s none, so if an asynchronous helper reactively triggers multiple times we use the latest resolved value, not the one from the latest promise. I can imagine some may want it to be the latter.
    * We've decided not do anything for now, document this behavior (it's technically a pitfall), and mark it as a subject it change.
* [x] Decide whether `@pending` should be `true` when a resolved helper is recalculated. Another option is to remove the value/error when restarted. In other words: is pending a state or a flag (the latter would work just like [SWR](https://swr.vercel.app/)).
    * We've decided to leave it as `false` for now (i.e., once resolved, `@pending` will never turn to `true` ever again), document this behavior, and mark it as a subject it change.
* [x] Unit tests for all sorts of cases described above and used in the below example.

<details>
<summary>A detailed example used for testing</summary>

```html
<template name="example">
  <pre>
    Cursors.
    1. #each,      cursorGetterSync:  {{#each      cursorGetterSync }}{{#if @index}} - {{/if}}{{_id}}{{/each}}
    2. #each,      cursorValueSync:   {{#each      cursorValueSync  }}{{#if @index}} - {{/if}}{{_id}}{{/each}}
    {{!-- #each expects an array or cursor. --}}
    3. {{!-- #each,      cursorGetterAsync: {{#each      cursorGetterAsync}}{{#if @index}} - {{/if}}{{_id}}{{/each}} --}}
    4. {{!-- #each,      cursorValueAsync:  {{#each      cursorValueAsync }}{{#if @index}} - {{/if}}{{_id}}{{/each}} --}}
    {{!-- #eachAwait does not exist yet. --}}
    5. {{!-- #eachAwait, cursorGetterAsync: {{#eachAwait cursorGetterAsync}}{{#if @index}} - {{/if}}{{_id}}{{/eachAwait}} --}}
    6. {{!-- #eachAwait, cursorGetterSync:  {{#eachAwait cursorGetterSync }}{{#if @index}} - {{/if}}{{_id}}{{/eachAwait}} --}}
    7. {{!-- #eachAwait, cursorValueAsync:  {{#eachAwait cursorValueAsync }}{{#if @index}} - {{/if}}{{_id}}{{/eachAwait}} --}}
    8. {{!-- #eachAwait, cursorValueSync:   {{#eachAwait cursorValueSync  }}{{#if @index}} - {{/if}}{{_id}}{{/eachAwait}} --}}

    Primitives.
    1. #let,      primitiveGetterAsync: {{#let      x=primitiveGetterAsync}}{{x}}{{/let}}
    2. #let,      primitiveGetterSync:  {{#let      x=primitiveGetterSync }}{{x}}{{/let}}
    3. #let,      primitiveValueAsync:  {{#let      x=primitiveValueAsync }}{{x}}{{/let}}
    4. #let,      primitiveValueSync:   {{#let      x=primitiveValueSync  }}{{x}}{{/let}}

    Objects (inner accessors).
    1. #let,      asyncObjectAsyncProperty: {{#let      x=asyncObjectAsyncProperty}}{{x.foo}}{{/let}}
    2. #let,      asyncObjectSyncProperty:  {{#let      x=asyncObjectSyncProperty }}{{x.foo}}{{/let}}
    3. #let,      syncObjectAsyncProperty:  {{#let      x=syncObjectAsyncProperty }}{{x.foo}}{{/let}}
    4. #let,      syncObjectSyncProperty:   {{#let      x=syncObjectSyncProperty  }}{{x.foo}}{{/let}}

    Objects (outer accessors).
    1. #let,      asyncObjectAsyncProperty: {{#let      x=asyncObjectAsyncProperty.foo}}{{x}}{{/let}}
    2. #let,      asyncObjectSyncProperty:  {{#let      x=asyncObjectSyncProperty.foo }}{{x}}{{/let}}
    3. #let,      syncObjectAsyncProperty:  {{#let      x=syncObjectAsyncProperty.foo }}{{x}}{{/let}}
    4. #let,      syncObjectSyncProperty:   {{#let      x=syncObjectSyncProperty.foo  }}{{x}}{{/let}}

    Async states of #let (single).
    1. (D) {{#let x=delayed }}{{#if @pending    }}x is pending{{/if}}{{#if @rejected    }}x rejected{{/if}}{{#if @resolved    }}x resolved: {{x}}{{/if}}{{/let}}
    2. (D) {{#let x=delayed }}{{#if @pending 'x'}}x is pending{{/if}}{{#if @rejected 'x'}}x rejected{{/if}}{{#if @resolved 'x'}}x resolved: {{x}}{{/if}}{{/let}}
    3. (P) {{#let x=pending }}{{#if @pending    }}x is pending{{/if}}{{#if @rejected    }}x rejected{{/if}}{{#if @resolved    }}x resolved: {{x}}{{/if}}{{/let}}
    4. (P) {{#let x=pending }}{{#if @pending 'x'}}x is pending{{/if}}{{#if @rejected 'x'}}x rejected{{/if}}{{#if @resolved 'x'}}x resolved: {{x}}{{/if}}{{/let}}
    5. (R) {{#let x=rejected}}{{#if @pending    }}x is pending{{/if}}{{#if @rejected    }}x rejected{{/if}}{{#if @resolved    }}x resolved: {{x}}{{/if}}{{/let}}
    6. (R) {{#let x=rejected}}{{#if @pending 'x'}}x is pending{{/if}}{{#if @rejected 'x'}}x rejected{{/if}}{{#if @resolved 'x'}}x resolved: {{x}}{{/if}}{{/let}}

    Async states of #let (multiple).
    1. (DD) {{#let x=delayed  y=delayed }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    2. (DP) {{#let x=delayed  y=pending }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    3. (DR) {{#let x=delayed  y=rejected}}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    4. (PD) {{#let x=pending  y=delayed }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    5. (PP) {{#let x=pending  y=pending }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    6. (PR) {{#let x=pending  y=rejected}}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    7. (RD) {{#let x=rejected y=delayed }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    8. (RP) {{#let x=rejected y=pending }}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}
    9. (RR) {{#let x=rejected y=rejected}}{{#if @pending}}pending{{else}}       {{/if}} {{#if @rejected}}rejected{{else}}        {{/if}} {{#if @resolved}}resolved: ({{x}}, {{y}}){{/if}}{{/let}}

    Reactive helpers.
    1. counterAsync(): {{#let x=counterAsync}}{{x}}{{/let}}
    2. counterSync():  {{#let x=counterSync }}{{x}}{{/let}}

    Nested #let.
    {{#let name=getName}}
      {{#let greeting=getGreeting}}
        {{#if @pending}}
          We are fetching your greeting...
        {{/if}}
        {{#if @rejected 'name'}}
          Sorry, an error occurred while fetching your name!
        {{/if}}
        {{#if @resolved 'greeting' 'name'}}
          {{greeting}}, {{name}}!
        {{/if}}
      {{/let}}
    {{/let}}
  </pre>
  <button>Increase counter</button>
</template>
```

```ts
import { Mongo } from 'meteor/mongo';
import { Random } from 'meteor/random';
import { ReactiveVar } from 'meteor/reactive-var';
import { Template } from 'meteor/templating';

import './main.html';

const Collection = new Mongo.Collection(null);
Collection.insertAsync({});
Collection.insertAsync({});
Collection.insertAsync({});

Template.example.onCreated(function () {
  this.counter = new ReactiveVar(0);
});

Template.example.events({
  'click button': (_, template) => template.counter.set(template.counter.get() + 1),
});

Template.example.helpers({
  // Cursors.
  cursorGetterAsync: () => Promise.resolve(Collection.find()),
  cursorGetterSync: () => Collection.find(),
  cursorValueAsync: Promise.resolve(Collection.find()),
  cursorValueSync: Collection.find(),

  // Primitives.
  primitiveGetterAsync: () => Promise.resolve(Random.id()),
  primitiveGetterSync: () => Random.id(),
  primitiveValueAsync: Promise.resolve(Random.id()),
  primitiveValueSync: Random.id(),

  // Objects.
  asyncObjectAsyncProperty: Promise.resolve({ foo: Promise.resolve(Random.id()) }),
  asyncObjectSyncProperty: Promise.resolve({ foo: Random.id() }),
  syncObjectAsyncProperty: { foo: Promise.resolve(Random.id()) },
  syncObjectSyncProperty: { foo: Random.id() },

  // Async states of #let.
  delayed: new Promise(resolve => setTimeout(() => resolve(Random.id()), 1000)),
  pending: new Promise(() => {}),
  rejected: Promise.reject(Random.id()),

  // Reactive helpers.
  counterAsync: async () => Template.instance().counter.get(),
  counterSync: () => Template.instance().counter.get(),

  // Nested #let.
  getGreeting: new Promise(resolve => setTimeout(() => resolve('Hi'), 2000)),
  getName: new Promise(resolve => setTimeout(() => resolve('John'), 1000)),
});
```

</details>
