### PR TITLE
Added support for `Promise`s in `Spacebars.call` and `Spacebars.dot`.

### DIFF
--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -531,6 +531,12 @@ Blaze._isContentEqual = function (a, b) {
  */
 Blaze.currentView = null;
 
+/**
+ * @template T
+ * @param {Blaze.View} view
+ * @param {() => T} func
+ * @returns {T}
+ */
 Blaze._withCurrentView = function (view, func) {
   var oldView = Blaze.currentView;
   try {

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -117,8 +117,48 @@ Spacebars.makeRaw = function (value) {
     return HTML.Raw(value);
 };
 
+// FIXME: Remove once `spacebars` can depend on `tracker@1.3.0` (Meteor 2.10.0).
+const _withComputation = Tracker.withComputation || function (computation, f) {
+  var previousComputation = Tracker.currentComputation;
+
+  Tracker.currentComputation = computation;
+  Tracker.active = !!computation;
+
+  try {
+    return f();
+  } finally {
+    Tracker.currentComputation = previousComputation;
+    Tracker.active = !!previousComputation;
+  }
+};
+
+/***
+ * @sumamry Executes `fn` with the resolved value of `promise` while preserving
+ * the context, i.e., `Blaze.currentView` and `Tracker.currentComputation`.
+ * @template T
+ * @template U
+ * @param {Promise<T>} promise
+ * @param {(x: T) => U} fn
+ * @returns {Promise<U>}
+ */
+function _thenWithContext(promise, fn) {
+  const computation = Tracker.currentComputation;
+  const view = Blaze.currentView;
+  return promise.then(value =>
+    Blaze._withCurrentView(view, () =>
+      _withComputation(computation, () =>
+        fn(value)
+      )
+    )
+  );
+}
+
 // If `value` is a function, evaluate its `args` (by calling them, if they
 // are functions), and then call it on them. Otherwise, return `value`.
+//
+// If any of the arguments is a `Promise` or a function returning one, then the
+// `value` will be called once all of the arguments resolve. If any of them
+// rejects, so will the call.
 //
 // If `value` is not a function and is not null, then this method will assert
 // that there are no args. We check for null before asserting because a user
@@ -128,9 +168,15 @@ Spacebars.call = function (value/*, args*/) {
   if (typeof value === 'function') {
     // Evaluate arguments by calling them if they are functions.
     var newArgs = [];
+    let anyIsPromise = false;
     for (var i = 1; i < arguments.length; i++) {
       var arg = arguments[i];
       newArgs[i-1] = (typeof arg === 'function' ? arg() : arg);
+      anyIsPromise = anyIsPromise || newArgs[i-1] instanceof Promise;
+    }
+
+    if (anyIsPromise) {
+      return _thenWithContext(Promise.all(newArgs), newArgs => value.apply(null, newArgs));
     }
 
     return value.apply(null, newArgs);
@@ -170,6 +216,10 @@ Spacebars.SafeString.prototype = Handlebars.SafeString.prototype;
 // a wrapped version of `baz` that always uses `foo.bar` as
 // `this`).
 //
+// If any of the intermediate values is a `Promise`, the result will be one as
+// well, i.e., accessing a field of a `Promise` results in a `Promise` of the
+// accessed field. Rejections are passed-through.
+//
 // In `Spacebars.dot(foo, "bar")`, `foo` is assumed to be either
 // a non-function value or a "fully-bound" function wrapping a value,
 // where fully-bound means it takes no arguments and ignores `this`.
@@ -199,6 +249,9 @@ Spacebars.dot = function (value, id1/*, id2, ...*/) {
 
   if (! value)
     return value; // falsy, don't index, pass through
+
+  if (value instanceof Promise)
+    return _thenWithContext(value, value => Spacebars.dot(value, id1));
 
   var result = value[id1];
   if (typeof result !== 'function')

--- a/packages/spacebars/spacebars_tests.js
+++ b/packages/spacebars/spacebars_tests.js
@@ -57,3 +57,27 @@ Tinytest.add("spacebars - Spacebars.dot", function (test) {
     }, 'inc')(8), 9);
 
 });
+
+Tinytest.add("spacebars - async - Spacebars.call", async test => {
+  const add = (x, y) => x + y;
+  test.equal(await Spacebars.call(add, 1, Promise.resolve(2)), 3);
+  test.equal(await Spacebars.call(add, Promise.resolve(1), 2), 3);
+  test.equal(await Spacebars.call(add, Promise.resolve(1), Promise.resolve(2)), 3);
+  test.equal(await Spacebars.call(add, 1, async () => 2), 3);
+  test.equal(await Spacebars.call(add, async () => 1, 2), 3);
+  test.equal(await Spacebars.call(add, async () => 1, async () => 2), 3);
+  test.equal(await Spacebars.call(add, Promise.reject(1), 2).catch(x => x), 1);
+  test.equal(await Spacebars.call(add, 1, Promise.reject(2)).catch(x => x), 2);
+  test.equal(await Spacebars.call(add, Promise.reject(1), Promise.reject(2)).catch(x => x), 1);
+});
+
+Tinytest.add("spacebars - async - Spacebars.dot", async test => {
+  test.equal(await Spacebars.dot(Promise.resolve(null), 'foo'), null);
+  test.equal(await Spacebars.dot(Promise.resolve({ foo: 1 }), 'foo'), 1);
+  test.equal(await Spacebars.dot(Promise.resolve({ foo: () => 1 }), 'foo'), 1);
+  test.equal(await Spacebars.dot(Promise.resolve({ foo: async () => 1 }), 'foo'), 1);
+  test.equal(await Spacebars.dot({ foo: Promise.resolve(1) }, 'foo'), 1);
+  test.equal(await Spacebars.dot({ foo: async () => 1 }, 'foo'), 1);
+  test.equal(await Spacebars.dot(() => ({ foo: async () => 1 }), 'foo'), 1);
+  test.equal(await Spacebars.dot(async () => ({ foo: async () => 1 }), 'foo'), 1);
+});


### PR DESCRIPTION
While #412 adds a way to unwrap `Promise`s in templates, here we'll focus on their usability. Currently, accessing a `Promise` results in `undefined` as they have very few accessible properties (most importantly, the resolved value is not there).

In this pull request, I made `Spacebars.call` and `Spacebars.dot` helpers aware of `Promise`s. The former resolves all of the arguments before calling the function, while the latter wraps property accesses in `Promise`s.

For details, please refer to the [newly added tests](https://github.com/meteor/blaze/pull/413/files#diff-88f4b0b1fc27941fdadab16c9d294823f271a74be57291b8dbde2750bb23d3aa).

_(Fun fact: there are 0 deleted lines in this pull request.)_

---

Once this and #412 will be merged, the "`await` unrolling" proposed before would not be needed. Consider the example from https://github.com/meteor/blaze/pull/409#issuecomment-1534702374:

```html
{{#if await someFunc ((await calcParamA) (await someOtherparamB)) (await calcParamB (await someOtherparamC) (someOtherparamD)) }}
    (...)
{{/if}}
```

This will have to unwrap the `Promise`, but the entire computation will be simple:

```html
{{#let result=(someFunc (calcParamA someOtherparamB) (calcParamB someOtherparamC someOtherparamD))}}
  {{#if result}}
    (...)
  {{/if}}
{{/let}}
```

Of course, it'll be possible to use the `@pending`, `@rejected`, and `@resolved` helpers to check the progress of calculating `result` as well.