### PR TITLE
Added support for `Promise`s in `#if` and `#each`.

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -352,6 +352,19 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
   return eachView;
 };
 
+/**
+ * Create a new `Blaze.Let` view that unwraps the given value.
+ * @param {unknown} value
+ * @returns {Blaze.View}
+ */
+Blaze._Await = function (value) {
+  return Blaze.Let({ value }, Blaze._AwaitContent);
+};
+
+Blaze._AwaitContent = function () {
+  return Blaze.currentView._scopeBindings.value.get()?.value;
+};
+
 Blaze._TemplateWith = function (arg, contentFunc) {
   var w;
 

--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -123,7 +123,8 @@ Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
     // has resolved. Rejected `Promise`s are NOT rendered.
     const condition = view.__conditionVar.get();
     if (condition && 'value' in condition) {
-      return Blaze._calculateCondition(condition.value) ? contentFunc() : (elseFunc ? elseFunc() : null);
+      const result = !Blaze._calculateCondition(condition.value) !== !_not;
+      return result ? contentFunc() : (elseFunc ? elseFunc() : null);
     }
 
     return null;

--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -49,31 +49,48 @@ function _isEqualBinding(x, y) {
 }
 
 /**
+ * Attaches a single binding to the instantiated view.
+ * @param {Blaze.View} view Target view.
+ * @param {string} name Binding name.
+ * @param {unknown} value Bound value.
+ */
+function _setBindingValue(reactiveVar, value) {
+  if (value && typeof value.then === 'function') {
+    value.then(
+      value => reactiveVar.set({ value }),
+      error => reactiveVar.set({ error }),
+    );
+  } else {
+    reactiveVar.set({ value });
+  }
+}
+
+/**
+ * @param {Blaze.View} view Target view.
+ * @param {unknown} binding Binding value or its getter.
+ * @param {string} [displayName] Autorun's display name.
+ */
+function _createBinding(view, binding, displayName) {
+  const reactiveVar = new ReactiveVar(undefined, _isEqualBinding);
+  if (typeof binding === 'function') {
+    view.autorun(() => _setBindingValue(reactiveVar, binding()), view.parentView, displayName);
+  } else {
+    _setBindingValue(reactiveVar, binding);
+  }
+
+  return reactiveVar;
+}
+
+/**
  * Attaches bindings to the instantiated view.
  * @param {Object} bindings A dictionary of bindings, each binding name
  * corresponds to a value or a function that will be reactively re-run.
  * @param {Blaze.View} view The target.
  */
 Blaze._attachBindingsToView = function (bindings, view) {
-  function setBindingValue(name, value) {
-    if (value && typeof value.then === 'function') {
-      value.then(
-        value => view._scopeBindings[name].set({ value }),
-        error => view._scopeBindings[name].set({ error }),
-      );
-    } else {
-      view._scopeBindings[name].set({ value });
-    }
-  }
-
   view.onViewCreated(function () {
     Object.entries(bindings).forEach(function ([name, binding]) {
-      view._scopeBindings[name] = new ReactiveVar(undefined, _isEqualBinding);
-      if (typeof binding === 'function') {
-        view.autorun(() => setBindingValue(name, binding()), view.parentView);
-      } else {
-        setBindingValue(name, binding);
-      }
+      view._scopeBindings[name] = _createBinding(view, binding);
     });
   });
 };
@@ -101,18 +118,20 @@ Blaze.Let = function (bindings, contentFunc) {
  *   `elseFunc` is supplied, no content is shown in the "else" case.
  */
 Blaze.If = function (conditionFunc, contentFunc, elseFunc, _not) {
-  var conditionVar = new ReactiveVar;
+  const view = Blaze.View(_not ? 'unless' : 'if', function () {
+    // Render only if the binding has a value, i.e., it's either synchronous or
+    // has resolved. Rejected `Promise`s are NOT rendered.
+    const condition = view.__conditionVar.get();
+    if (condition && 'value' in condition) {
+      return Blaze._calculateCondition(condition.value) ? contentFunc() : (elseFunc ? elseFunc() : null);
+    }
 
-  var view = Blaze.View(_not ? 'unless' : 'if', function () {
-    return conditionVar.get() ? contentFunc() :
-      (elseFunc ? elseFunc() : null);
+    return null;
   });
-  view.__conditionVar = conditionVar;
-  view.onViewCreated(function () {
-    this.autorun(function () {
-      var cond = Blaze._calculateCondition(conditionFunc());
-      conditionVar.set(_not ? (! cond) : cond);
-    }, this.parentView, 'condition');
+
+  view.__conditionVar = null;
+  view.onViewCreated(() => {
+    view.__conditionVar = _createBinding(view, conditionFunc, 'condition');
   });
 
   return view;
@@ -167,7 +186,7 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
   eachView.stopHandle = null;
   eachView.contentFunc = contentFunc;
   eachView.elseFunc = elseFunc;
-  eachView.argVar = new ReactiveVar;
+  eachView.argVar = _createBinding(eachView, []);
   eachView.variableName = null;
 
   // update the @index value in the scope of all subviews in the range
@@ -195,11 +214,11 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
         arg = arg._sequence;
       }
 
-      eachView.argVar.set(arg);
+      _setBindingValue(eachView.argVar, arg);
     }, eachView.parentView, 'collection');
 
     eachView.stopHandle = ObserveSequence.observe(function () {
-      return eachView.argVar.get();
+      return eachView.argVar.get()?.value;
     }, {
       addedAt: function (id, item, index) {
         Tracker.nonreactive(function () {

--- a/packages/blaze/materializer.js
+++ b/packages/blaze/materializer.js
@@ -93,7 +93,7 @@ var materializeDOMInner = function (htmljs, intoArray, parentView, workStack) {
   throw new Error("Unexpected object in htmljs: " + htmljs);
 };
 
-const isPromiseLike = x => typeof x?.then === 'function';
+const isPromiseLike = x => !!x && typeof x.then === 'function';
 
 function waitForAllAttributesAndContinue(attrs, fn) {
   const promises = [];

--- a/packages/htmljs/visitors.js
+++ b/packages/htmljs/visitors.js
@@ -172,6 +172,10 @@ TransformingVisitor.def({
     }
 
     if (attrs && isConstructedObject(attrs)) {
+      if (typeof attrs.then === 'function') {
+        throw new Error('Asynchronous attributes are not supported. Use #let to unwrap them first.');
+      }
+
       throw new Error("The basic TransformingVisitor does not support " +
                       "foreign objects in attributes.  Define a custom " +
                       "visitAttributes for this case.");

--- a/packages/spacebars-tests/async_tests.html
+++ b/packages/spacebars-tests/async_tests.html
@@ -67,3 +67,21 @@
     {{/let}}
   {{/let}}
 </template>
+
+<template name="spacebars_async_tests_if">
+  {{#if x}}1{{/if}}
+  {{#if x}}1{{else}}2{{/if}}
+</template>
+
+<template name="spacebars_async_tests_unless">
+  {{#unless x}}1{{/unless}}
+  {{#unless x}}1{{else}}2{{/unless}}
+</template>
+
+<template name="spacebars_async_tests_each_old">
+  {{#each x}}{{.}}{{else}}0{{/each}}
+</template>
+
+<template name="spacebars_async_tests_each_new">
+  {{#each y in x}}{{y}}{{else}}0{{/each}}
+</template>

--- a/packages/spacebars-tests/async_tests.html
+++ b/packages/spacebars-tests/async_tests.html
@@ -68,6 +68,22 @@
   {{/let}}
 </template>
 
+<template name="spacebars_async_tests_attribute">
+  <img class={{x}}>
+</template>
+
+<template name="spacebars_async_tests_attributes">
+  <img {{x}}>
+</template>
+
+<template name="spacebars_async_tests_value_direct">
+  {{x}}
+</template>
+
+<template name="spacebars_async_tests_value_raw">
+  {{{x}}}
+</template>
+
 <template name="spacebars_async_tests_if">
   {{#if x}}1{{/if}}
   {{#if x}}1{{else}}2{{/if}}

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -1,5 +1,6 @@
 function asyncTest(templateName, testName, fn) {
-  Tinytest.addAsync(`spacebars-tests - async - ${templateName} ${testName}`, test => {
+  const name = [templateName, testName].filter(Boolean).join(' ');
+  Tinytest.addAsync(`spacebars-tests - async - ${name}`, test => {
     const template = Blaze.Template[`spacebars_async_tests_${templateName}`];
     const templateCopy = new Blaze.Template(template.viewName, template.renderFunction);
     return fn(test, templateCopy, () => {
@@ -41,6 +42,30 @@ asyncTest('missing1', 'outer', async (test, template, render) => {
 asyncTest('missing2', 'inner', async (test, template, render) => {
   Blaze._throwNextException = true;
   test.throws(render, 'Binding for "b" was not found.');
+});
+
+asyncTest('attribute', '', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  template.helpers({ x: Promise.resolve() });
+  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
+});
+
+asyncTest('attributes', '', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  template.helpers({ x: Promise.resolve() });
+  test.throws(render, 'Asynchronous attributes are not supported. Use #let to unwrap them first.');
+});
+
+asyncTest('value_direct', '', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  template.helpers({ x: Promise.resolve() });
+  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
+});
+
+asyncTest('value_raw', '', async (test, template, render) => {
+  Blaze._throwNextException = true;
+  template.helpers({ x: Promise.resolve() });
+  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
 });
 
 asyncSuite('if', [

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -43,6 +43,30 @@ asyncTest('missing2', 'inner', async (test, template, render) => {
   test.throws(render, 'Binding for "b" was not found.');
 });
 
+asyncSuite('if', [
+  ['false', { x: Promise.resolve(false) }, '', '2'],
+  ['true', { x: Promise.resolve(true) }, '', '1 1'],
+]);
+
+asyncSuite('unless', [
+  ['false', { x: Promise.resolve(false) }, '', '1 1'],
+  ['true', { x: Promise.resolve(true) }, '', '2'],
+]);
+
+asyncSuite('each_old', [
+  ['null', { x: Promise.resolve(null) }, '0', '0'],
+  ['empty', { x: Promise.resolve([]) }, '0', '0'],
+  ['one', { x: Promise.resolve([1]) }, '0', '1'],
+  ['two', { x: Promise.resolve([1, 2]) }, '0', '12'],
+]);
+
+asyncSuite('each_new', [
+  ['null', { x: Promise.resolve(null) }, '0', '0'],
+  ['empty', { x: Promise.resolve([]) }, '0', '0'],
+  ['one', { x: Promise.resolve([1]) }, '0', '1'],
+  ['two', { x: Promise.resolve([1, 2]) }, '0', '12'],
+]);
+
 // In the following tests pending=1, rejected=2, resolved=3.
 const pending = new Promise(() => {});
 const rejected = Promise.reject();

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -22,16 +22,20 @@ function asyncSuite(templateName, cases) {
   }
 }
 
+const getter = async () => 'foo';
+const thenable = { then: resolve => Promise.resolve().then(() => resolve('foo')) };
+const value = Promise.resolve('foo');
+
 asyncSuite('access', [
-  ['getter', { x: { y: async () => 'foo' } }, '', 'foo'],
-  ['thenable', { x: { y: { then: resolve => { Promise.resolve().then(() => resolve('foo')) } } } }, '', 'foo'],
-  ['value', { x: { y: Promise.resolve('foo') } }, '', 'foo'],
+  ['getter', { x: { y: getter } }, '', 'foo'],
+  ['thenable', { x: { y: thenable } }, '', 'foo'],
+  ['value', { x: { y: value } }, '', 'foo'],
 ]);
 
 asyncSuite('direct', [
-  ['getter', { x: async () => 'foo' }, '', 'foo'],
-  ['thenable', { x: { then: resolve => { Promise.resolve().then(() => resolve('foo')) } } }, '', 'foo'],
-  ['value', { x: Promise.resolve('foo') }, '', 'foo'],
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
 ]);
 
 asyncTest('missing1', 'outer', async (test, template, render) => {
@@ -44,11 +48,11 @@ asyncTest('missing2', 'inner', async (test, template, render) => {
   test.throws(render, 'Binding for "b" was not found.');
 });
 
-asyncTest('attribute', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('attribute', [
+  ['getter', { x: getter }, '<img>', '<img class="foo">'],
+  ['thenable', { x: thenable }, '<img>', '<img class="foo">'],
+  ['value', { x: value }, '<img>', '<img class="foo">'],
+]);
 
 asyncTest('attributes', '', async (test, template, render) => {
   Blaze._throwNextException = true;
@@ -56,17 +60,17 @@ asyncTest('attributes', '', async (test, template, render) => {
   test.throws(render, 'Asynchronous attributes are not supported. Use #let to unwrap them first.');
 });
 
-asyncTest('value_direct', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('value_direct', [
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
+]);
 
-asyncTest('value_raw', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('value_raw', [
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
+]);
 
 asyncSuite('if', [
   ['false', { x: Promise.resolve(false) }, '', '2'],

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -175,7 +175,7 @@ Spacebars.call = function (value/*, args*/) {
   }
 };
 
-const isPromiseLike = x => typeof x?.then === 'function';
+const isPromiseLike = x => !!x && typeof x.then === 'function';
 
 // Call this as `Spacebars.kw({ ... })`.  The return value
 // is `instanceof Spacebars.kw`.

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -75,6 +75,8 @@ Spacebars.mustache = function (value/*, args*/) {
 
   if (result instanceof Spacebars.SafeString)
     return HTML.Raw(result.toString());
+  else if (isPromiseLike(value))
+    throw new Error('Asynchronous values are not serializable. Use #let to unwrap them first.');
   else
     // map `null`, `undefined`, and `false` to null, which is important
     // so that attributes with nully values are considered absent.

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -75,8 +75,8 @@ Spacebars.mustache = function (value/*, args*/) {
 
   if (result instanceof Spacebars.SafeString)
     return HTML.Raw(result.toString());
-  else if (isPromiseLike(value))
-    throw new Error('Asynchronous values are not serializable. Use #let to unwrap them first.');
+  else if (isPromiseLike(result))
+    return result;
   else
     // map `null`, `undefined`, and `false` to null, which is important
     // so that attributes with nully values are considered absent.
@@ -113,7 +113,7 @@ Spacebars.dataMustache = function (value/*, args*/) {
 Spacebars.makeRaw = function (value) {
   if (value == null) // null or undefined
     return null;
-  else if (value instanceof HTML.Raw)
+  else if (value instanceof HTML.Raw || isPromiseLike(value))
     return value;
   else
     return HTML.Raw(value);
@@ -233,7 +233,7 @@ Spacebars.dot = function (value, id1/*, id2, ...*/) {
     return Spacebars.dot.apply(null, argsForRecurse);
   }
 
-  if (typeof value === 'function')
+  while (typeof value === 'function')
     value = value();
 
   if (! value)

--- a/packages/spacebars/spacebars_tests.js
+++ b/packages/spacebars/spacebars_tests.js
@@ -81,6 +81,10 @@ Tinytest.addAsync("spacebars - async - Spacebars.dot", async test => {
   test.equal(await Spacebars.dot(Promise.resolve({ x: async () => o }), 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: { then: resolve => resolve(o) } }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: Promise.resolve(o) }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: () => () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: () => async () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: async () => () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: async () => async () => o }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: async () => o }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot(() => ({ x: async () => o }), 'x', 'y'), 1);
   test.equal(await Spacebars.dot(async () => ({ x: async () => o }), 'x', 'y'), 1);

--- a/packages/spacebars/spacebars_tests.js
+++ b/packages/spacebars/spacebars_tests.js
@@ -58,7 +58,7 @@ Tinytest.add("spacebars - Spacebars.dot", function (test) {
 
 });
 
-Tinytest.add("spacebars - async - Spacebars.call", async test => {
+Tinytest.addAsync("spacebars - async - Spacebars.call", async test => {
   const add = (x, y) => x + y;
   test.equal(await Spacebars.call(add, 1, Promise.resolve(2)), 3);
   test.equal(await Spacebars.call(add, Promise.resolve(1), 2), 3);
@@ -73,14 +73,15 @@ Tinytest.add("spacebars - async - Spacebars.call", async test => {
   test.equal(await Spacebars.call(add, Promise.reject(1), Promise.reject(2)).catch(x => x), 1);
 });
 
-Tinytest.add("spacebars - async - Spacebars.dot", async test => {
-  test.equal(await Spacebars.dot(Promise.resolve(null), 'foo'), null);
-  test.equal(await Spacebars.dot(Promise.resolve({ foo: 1 }), 'foo'), 1);
-  test.equal(await Spacebars.dot(Promise.resolve({ foo: () => 1 }), 'foo'), 1);
-  test.equal(await Spacebars.dot(Promise.resolve({ foo: async () => 1 }), 'foo'), 1);
-  test.equal(await Spacebars.dot({ foo: { then: resolve => resolve(1) } }, 'foo'), 1);
-  test.equal(await Spacebars.dot({ foo: Promise.resolve(1) }, 'foo'), 1);
-  test.equal(await Spacebars.dot({ foo: async () => 1 }, 'foo'), 1);
-  test.equal(await Spacebars.dot(() => ({ foo: async () => 1 }), 'foo'), 1);
-  test.equal(await Spacebars.dot(async () => ({ foo: async () => 1 }), 'foo'), 1);
+Tinytest.addAsync("spacebars - async - Spacebars.dot", async test => {
+  const o = { y: 1 };
+  test.equal(await Spacebars.dot(Promise.resolve(null), 'x', 'y'), null);
+  test.equal(await Spacebars.dot(Promise.resolve({ x: o }), 'x', 'y'), 1);
+  test.equal(await Spacebars.dot(Promise.resolve({ x: () => o }), 'x', 'y'), 1);
+  test.equal(await Spacebars.dot(Promise.resolve({ x: async () => o }), 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: { then: resolve => resolve(o) } }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: Promise.resolve(o) }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: async () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot(() => ({ x: async () => o }), 'x', 'y'), 1);
+  test.equal(await Spacebars.dot(async () => ({ x: async () => o }), 'x', 'y'), 1);
 });

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -166,9 +166,9 @@ and not all tags are allowed at all locations.
 ### Double-braced Tags
 
 A double-braced tag at element level or in an attribute value typically evalutes
-to a string.  If it evalutes to something else, the value will be cast to a
+to a string. If it evalutes to something else, the value will be cast to a
 string, unless the value is `null`, `undefined`, or `false`, which results in
-nothing being displayed.
+nothing being displayed. `Promise`s are not supported and will throw an error.
 
 Values returned from helpers must be pure text, not HTML.  (That is, strings
 should have `<`, not `&lt;`.)  Spacebars will perform any necessary escaping if
@@ -205,11 +205,11 @@ of attributes:
 ```
 
 The tag must evaluate to an object that serves as a dictionary of attribute name
-and value strings.  For convenience, the value may also be a string or null.  An
-empty string or null expands to `{}`.  A non-empty string must be an attribute
+and value strings. For convenience, the value may also be a string or null. An
+empty string or null expands to `{}`. A non-empty string must be an attribute
 name, and expands to an attribute with an empty value; for example, `"checked"`
 expands to `{checked: ""}` (which, as far as HTML is concerned, means the
-checkbox is checked).
+checkbox is checked). `Promise`s are not supported and will throw an error.
 
 To summarize:
 
@@ -223,6 +223,7 @@ To summarize:
     <tr><td><code>{checked: "", 'class': "foo"}</code></td><td><code>checked  class=foo</code></td></tr>
     <tr><td><code>{checked: false, 'class': "foo"}</code></td><td><code>class=foo</code></td></tr>
     <tr><td><code>"checked class=foo"</code></td><td>ERROR, string is not an attribute name</td></tr>
+    <tr><td><code>Promise.resolve({})</code></td><td>ERROR, asynchronous attributes are not supported</td></tr>
   </tbody>
 </table>
 

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -357,6 +357,16 @@ well as the empty array, while any other value is considered true.
 
 `#unless` is just `#if` with the condition inverted.
 
+### Async conditions
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/424).
+
+The condition can be wrapped in a `Promise`. When that happens, both `#if` and
+`#unless` will not render anything if it's pending or rejected. Once resolved,
+the resulting value is used. To have more fine-grained handling of non-resolved
+states, use `#let` and the async state helpers (e.g., `@pending`).
+
 ## With
 
 A `#with` template tag establishes a new data context object for its contents.
@@ -422,6 +432,16 @@ context) if there are zero items in the sequence at any time.
 
 You can use a special variable `@index` in the body of `#each` to get the
 0-based index of the currently rendered value in the sequence.
+
+### Async sequences
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/424).
+
+The sequence argument can be wrapped in a `Promise`. When that happens, `#each`
+will render the "else" if it's pending or rejected. Once resolved, the resulting
+sequence is used. To have more fine-grained handling of non-resolved states, use
+`#let` and the async state helpers (e.g., `@pending`).
 
 ### Reactivity Model for Each
 

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -168,11 +168,21 @@ and not all tags are allowed at all locations.
 A double-braced tag at element level or in an attribute value typically evalutes
 to a string. If it evalutes to something else, the value will be cast to a
 string, unless the value is `null`, `undefined`, or `false`, which results in
-nothing being displayed. `Promise`s are not supported and will throw an error.
+nothing being displayed. `Promise`s are also supported -- see below.
 
 Values returned from helpers must be pure text, not HTML.  (That is, strings
 should have `<`, not `&lt;`.)  Spacebars will perform any necessary escaping if
 a template is rendered to HTML.
+
+### Async content
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The values can be wrapped in a `Promise`. When that happens, it will be treated
+as `undefined` while it's pending or rejected. Once resolved, the resulting
+value is used. To have more fine-grained handling of non-resolved states, use
+`#let` and the async state helpers (e.g., `@pending`).
 
 ### SafeString
 
@@ -192,6 +202,16 @@ A double-braced tag may be part of, or all of, an HTML attribute value:
 An attribute value that consists entirely of template tags that return `null`,
 `undefined`, or `false` is considered absent; otherwise, the attribute is
 considered present, even if its value is empty.
+
+### Async attributes
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The values can be wrapped in a `Promise`. When that happens, it will be treated
+as `undefined` while it's pending or rejected. Once resolved, the resulting
+value is used. To have more fine-grained handling of non-resolved states, use
+`#let` and the async state helpers (e.g., `@pending`).
 
 ### Dynamic Attributes
 
@@ -255,6 +275,16 @@ The inserted HTML must consist of balanced HTML tags.  You can't, for example,
 insert `"</div><div>"` to close an existing div and open a new one.
 
 This template tag cannot be used in attributes or in an HTML start tag.
+
+### Async content
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The raw HTML can be wrapped in a `Promise`. When that happens, it will not
+render anything if it's pending or rejected. Once resolved, the resulting value
+is used. To have more fine-grained handling of non-resolved states, use `#let`
+and the async state helpers (e.g., `@pending`).
 
 ## Inclusion Tags
 


### PR DESCRIPTION
In this pull request, I follow up on #412 and #413 by supporting `Promise`s in `#if`/`#unless` and `#each`. The idea is basically the same as how it works in `#let` except for where we actually store the `ReactiveVar`s.

To do:
- [x] **`#if`/`#unless` ~and `#each`~ are not rendering anything before the `Promise` resolves.** That's to make it clear that there's nothing there. I'm open for suggestions though, as I can imagine cases where `{{else}}` is more expected.
    * I asked a couple of people and they said it's fine not to render anything as in "not to make any decisions before the value is known".
    * Due to the complexity, `#each` will treat unresolved `Promise`s as empty sequences and thus render the `{{else}}` block. We may change that in the future.
- [x] **`#if`/`#unless` ~and `#each`~ are not rendering anything for rejected `Promise`s.** This is a sane choice, but I want to confirm that with the community.
    * I asked a couple of people and they said it's fine not to render anything as in "not to make any decisions before the value is known".
    * Due to the complexity, `#each` will treat rejected `Promise`s as empty sequences and thus render the `{{else}}` block. We may change that in the future.
- [x] Tests.
- [x] Documentation.
- [x] Decide whether or not we want to preserve the `if.__conditionVar` and `each.argVar`. They're not used anywhere, but _sometimes_ it makes sense (e.g., `#with` depends on that).
    * I decided to leave them for now, but there's quite a few potential simplifications in this area. They may improve the performance as well.

**Note:** #428 got merged into this branch!