### PR TITLE
Add Template.autorunAsync to allow for await-able autorun blocks

### DIFF
--- a/packages/blaze/template.js
+++ b/packages/blaze/template.js
@@ -331,6 +331,18 @@ Blaze.TemplateInstance.prototype.autorun = function (f) {
 };
 
 /**
+ * @summary An await-able version of [Tracker.autorun](https://docs.meteor.com/api/tracker.html#Tracker-autorun) that is stopped when the template is destroyed.
+ * @locus Client
+ * @param {Function} runFunc The function to run. It receives one argument: a Tracker.Computation object.
+ *
+ * @return {Promise} computation  - a promise for the computation object.
+ */
+Blaze.TemplateInstance.prototype.autorunAsync = function (f) {
+  return this.view.autorunAsync(f);
+};
+
+
+/**
  * @summary A version of [Meteor.subscribe](https://docs.meteor.com/api/pubsub.html#Meteor-subscribe) that is stopped
  * when the template is destroyed.
  * @return {SubscriptionHandle} The subscription handle to the newly made

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -223,6 +223,28 @@ Blaze.View.prototype.autorun = function (f, _inViewScope, displayName) {
   return comp;
 };
 
+/**
+ * An await-able variant of the regular View.autorun
+ *
+ * @param f
+ * @param _inViewScope
+ * @param displayName
+ * @return {Promise} computation object   - returns a promise for the computation object
+ */
+Blaze.View.prototype.autorunAsync = function(f, _inViewScope, displayName) {
+  let fPromise
+  let self = this
+  const newF = async(...args) => {
+    fPromise = f(...args)
+  }
+
+  const c = Blaze.View.prototype.autorun.call(this, newF, _inViewScope, displayName)
+
+  return fPromise.then(() => {
+    return c
+  })
+}
+
 Blaze.View.prototype._errorIfShouldntCallSubscribe = function () {
   var self = this;
 


### PR DESCRIPTION
PR which adds a new, `await`-able `Template.autorunAsync` to allow autorun blocks with async autorun functions to be run in a predictable manner.

There's also a separate PR on the main meteor repo with an equivalent `Tracker.autorunAsync` function: [Add Tracker.autorunAsync to allow for await-able autorun blocks #12801.](https://github.com/meteor/meteor/pull/12801)

The explanations in both PRs are basically identical, so if you understood the first one, you got both, only one's for `Tracker.autorunAsync`, and the other one is for `Template.aurorunAsync`.

The issue I'm trying to mitigate is this:

Having multiple "traditional" autorun blocks in a row like this, with async autorun funcs:

```
Template.myTemplate.onCreated(async function () {
    // autorun 1
    this.autorun(async(c) => {
        // 1
        await Tracker.withComputation(c, () => { ... }) 
        // 2
        await Tracker.withComputation(c, () => { ... }) 
        // 3
        await Tracker.withComputation(c, () => { ... })     
        // 4
    })

    // autorun 2
    this.autorun(async(c) => {
        // 5
        await Tracker.withComputation(c, () => { ... }) 
        // 6
        await Tracker.withComputation(c, () => { ... }) 
        // 7
        await Tracker.withComputation(c, () => { ... })     
        // 8
    })

    // autorun 3
    this.autorun(async(c) => {
        // 9
        await Tracker.withComputation(c, () => { ... }) 
        // 10
        await Tracker.withComputation(c, () => { ... }) 
        // 11
        await Tracker.withComputation(c, () => { ... })     
        // 12
    })
})
```

... will lead to **each autorun being entered, executed til after the first `await`, then the interpreter will skip the rest of the autorun function, start with the next synchronous task in the script, eg. the autorun2 function.**

There it'll run til after the first `await` & yield, and then again with the third block.

After that all bets are off: Whenever some of the awaited code returns, it'll be continued eventually. Until the next await block.. :D 

**So the interpreter will actually zig-zag back and forth between the different Autorun blocks until all the awaits have been passed and finished.**

That makes it really hard to reason about the autoruns & probably might lead to issues during runtime too, eg. certain subscriptions not being made / ready because the interpreter "skipped ahead" a previous autorun, which until async were guaranteed to run in order once.

It gets even more fun if you start looking at the different template lifecycle functions like onCreated and onRendered for example:

```

Template.onCreated(function() {
    // autorun 1
    this.autorun(async(c) => {
        // 1
        await Tracker.withComputation(c, () => { ... }) 
        // 2
        // (...)
    })

    // autorun 2
    this.autorun(async(c) => {
        // 5
        await Tracker.withComputation(c, () => { ... }) 
        // 6
        // (...)
    })

    // autorun 3
    this.autorun(async(c) => {
        // 9
        await Tracker.withComputation(c, () => { ... }) 
        // 10
        // (...)
    })
})

Template.onRendered(function() {
    // autorun 4
    Tracker.autorun(async(c) => {
        // 13
        await Tracker.withComputation(c, () => { ... }) 
        // 14
        // (...)
    })
})

```

Here, autorun 4 in `onRendered` will be started to be executed _before_ any of the first autoruns have been ran through completely, if that makes sense.

The only way I could conceive to put everything "in order" again was to use `async` function in `onCreated` and `onRendered` and then making the autorun blocks `await`able by awaiting each one in turn.

This way it'd also be possible to wait for the `rendered` event by setting eg. a reactive var in `onRendered` and checking that in `onCreated` (or wherever you want) in an autorun...

---

So then the above code could look like this with my added `Template.autorunAsync` function:

```

Template.onCreated(async function() {
    // autorun 1
    await this.autorunAsync(async(c) => {
        // 1
        await Tracker.withComputation(c, () => { ... }) 
        // 2
        // (...)
    })

    // autorun 2
    await this.autorunAsync(async(c) => {
        // 5
        await Tracker.withComputation(c, () => { ... }) 
        // 6
        // (...)
    })

    // autorun 3
    await this.autorunAsync(async(c) => {
        // 9
        await Tracker.withComputation(c, () => { ... }) 
        // 10
        // (...)
    })
})

Template.onRendered(async function() {
    // autorun 4
    await this.autorunAsync(async(c) => {
        // 13
        await Tracker.withComputation(c, () => { ... }) 
        // 14
        // (...)
    })
})

```

**This forces all the code in the autorun blocks to run in their _expected_ order again.** It's possible to _reason_ again about the order of things. Otherwise there might be a lot of really hard to debug race conditions.

The good thing is, the PR adds a new function, `Template.autorunAsync`, so it shouldn't break any existing code.

I've adopted the *Async syntax here for easy differentiation between Async and not-Async variants.

I'm not sure if that means that in the future / with 3.0 we should _only_ use the `autorunAsync` - functions, but for now I think its good to have these in there explicitly as an option.

I'm not sure if this should go into the mainline immediately? Please, I'd be happy for some feedback.

Also, sorry, there's no

a) Typescript definitions - I have no clue about that, but probably could fumble something together, but I wouldn't actually know how to check whether it'd be correct either
b) Tests - sorry guys
c) Nothing added to the Blaze Docs yet - let me know if this is something which might actually make it into meteor and I'll gladly add some lines to the docs.

Thx & best!