### PR TITLE
Implemented async attributes and content.

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -352,6 +352,19 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
   return eachView;
 };
 
+/**
+ * Create a new `Blaze.Let` view that unwraps the given value.
+ * @param {unknown} value
+ * @returns {Blaze.View}
+ */
+Blaze._Await = function (value) {
+  return Blaze.Let({ value }, Blaze._AwaitContent);
+};
+
+Blaze._AwaitContent = function () {
+  return Blaze.currentView._scopeBindings.value.get()?.value;
+};
+
 Blaze._TemplateWith = function (arg, contentFunc) {
   var w;
 

--- a/packages/blaze/materializer.js
+++ b/packages/blaze/materializer.js
@@ -93,7 +93,7 @@ var materializeDOMInner = function (htmljs, intoArray, parentView, workStack) {
   throw new Error("Unexpected object in htmljs: " + htmljs);
 };
 
-const isPromiseLike = x => typeof x?.then === 'function';
+const isPromiseLike = x => !!x && typeof x.then === 'function';
 
 function waitForAllAttributesAndContinue(attrs, fn) {
   const promises = [];

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -22,16 +22,20 @@ function asyncSuite(templateName, cases) {
   }
 }
 
+const getter = async () => 'foo';
+const thenable = { then: resolve => Promise.resolve().then(() => resolve('foo')) };
+const value = Promise.resolve('foo');
+
 asyncSuite('access', [
-  ['getter', { x: { y: async () => 'foo' } }, '', 'foo'],
-  ['thenable', { x: { y: { then: resolve => { Promise.resolve().then(() => resolve('foo')) } } } }, '', 'foo'],
-  ['value', { x: { y: Promise.resolve('foo') } }, '', 'foo'],
+  ['getter', { x: { y: getter } }, '', 'foo'],
+  ['thenable', { x: { y: thenable } }, '', 'foo'],
+  ['value', { x: { y: value } }, '', 'foo'],
 ]);
 
 asyncSuite('direct', [
-  ['getter', { x: async () => 'foo' }, '', 'foo'],
-  ['thenable', { x: { then: resolve => { Promise.resolve().then(() => resolve('foo')) } } }, '', 'foo'],
-  ['value', { x: Promise.resolve('foo') }, '', 'foo'],
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
 ]);
 
 asyncTest('missing1', 'outer', async (test, template, render) => {
@@ -44,11 +48,11 @@ asyncTest('missing2', 'inner', async (test, template, render) => {
   test.throws(render, 'Binding for "b" was not found.');
 });
 
-asyncTest('attribute', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('attribute', [
+  ['getter', { x: getter }, '<img>', '<img class="foo">'],
+  ['thenable', { x: thenable }, '<img>', '<img class="foo">'],
+  ['value', { x: value }, '<img>', '<img class="foo">'],
+]);
 
 asyncTest('attributes', '', async (test, template, render) => {
   Blaze._throwNextException = true;
@@ -56,17 +60,17 @@ asyncTest('attributes', '', async (test, template, render) => {
   test.throws(render, 'Asynchronous attributes are not supported. Use #let to unwrap them first.');
 });
 
-asyncTest('value_direct', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('value_direct', [
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
+]);
 
-asyncTest('value_raw', '', async (test, template, render) => {
-  Blaze._throwNextException = true;
-  template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous values are not serializable. Use #let to unwrap them first.');
-});
+asyncSuite('value_raw', [
+  ['getter', { x: getter }, '', 'foo'],
+  ['thenable', { x: thenable }, '', 'foo'],
+  ['value', { x: value }, '', 'foo'],
+]);
 
 asyncSuite('if', [
   ['false', { x: Promise.resolve(false) }, '', '2'],

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -175,7 +175,7 @@ Spacebars.call = function (value/*, args*/) {
   }
 };
 
-const isPromiseLike = x => typeof x?.then === 'function';
+const isPromiseLike = x => !!x && typeof x.then === 'function';
 
 // Call this as `Spacebars.kw({ ... })`.  The return value
 // is `instanceof Spacebars.kw`.

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -75,8 +75,8 @@ Spacebars.mustache = function (value/*, args*/) {
 
   if (result instanceof Spacebars.SafeString)
     return HTML.Raw(result.toString());
-  else if (isPromiseLike(value))
-    throw new Error('Asynchronous values are not serializable. Use #let to unwrap them first.');
+  else if (isPromiseLike(result))
+    return result;
   else
     // map `null`, `undefined`, and `false` to null, which is important
     // so that attributes with nully values are considered absent.
@@ -113,7 +113,7 @@ Spacebars.dataMustache = function (value/*, args*/) {
 Spacebars.makeRaw = function (value) {
   if (value == null) // null or undefined
     return null;
-  else if (value instanceof HTML.Raw)
+  else if (value instanceof HTML.Raw || isPromiseLike(value))
     return value;
   else
     return HTML.Raw(value);
@@ -233,7 +233,7 @@ Spacebars.dot = function (value, id1/*, id2, ...*/) {
     return Spacebars.dot.apply(null, argsForRecurse);
   }
 
-  if (typeof value === 'function')
+  while (typeof value === 'function')
     value = value();
 
   if (! value)

--- a/packages/spacebars/spacebars_tests.js
+++ b/packages/spacebars/spacebars_tests.js
@@ -81,6 +81,10 @@ Tinytest.addAsync("spacebars - async - Spacebars.dot", async test => {
   test.equal(await Spacebars.dot(Promise.resolve({ x: async () => o }), 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: { then: resolve => resolve(o) } }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: Promise.resolve(o) }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: () => () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: () => async () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: async () => () => o }, 'x', 'y'), 1);
+  test.equal(await Spacebars.dot({ x: async () => async () => o }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot({ x: async () => o }, 'x', 'y'), 1);
   test.equal(await Spacebars.dot(() => ({ x: async () => o }), 'x', 'y'), 1);
   test.equal(await Spacebars.dot(async () => ({ x: async () => o }), 'x', 'y'), 1);

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -168,11 +168,21 @@ and not all tags are allowed at all locations.
 A double-braced tag at element level or in an attribute value typically evalutes
 to a string. If it evalutes to something else, the value will be cast to a
 string, unless the value is `null`, `undefined`, or `false`, which results in
-nothing being displayed. `Promise`s are not supported and will throw an error.
+nothing being displayed. `Promise`s are also supported -- see below.
 
 Values returned from helpers must be pure text, not HTML.  (That is, strings
 should have `<`, not `&lt;`.)  Spacebars will perform any necessary escaping if
 a template is rendered to HTML.
+
+### Async content
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The values can be wrapped in a `Promise`. When that happens, it will be treated
+as `undefined` while it's pending or rejected. Once resolved, the resulting
+value is used. To have more fine-grained handling of non-resolved states, use
+`#let` and the async state helpers (e.g., `@pending`).
 
 ### SafeString
 
@@ -192,6 +202,16 @@ A double-braced tag may be part of, or all of, an HTML attribute value:
 An attribute value that consists entirely of template tags that return `null`,
 `undefined`, or `false` is considered absent; otherwise, the attribute is
 considered present, even if its value is empty.
+
+### Async attributes
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The values can be wrapped in a `Promise`. When that happens, it will be treated
+as `undefined` while it's pending or rejected. Once resolved, the resulting
+value is used. To have more fine-grained handling of non-resolved states, use
+`#let` and the async state helpers (e.g., `@pending`).
 
 ### Dynamic Attributes
 
@@ -255,6 +275,16 @@ The inserted HTML must consist of balanced HTML tags.  You can't, for example,
 insert `"</div><div>"` to close an existing div and open a new one.
 
 This template tag cannot be used in attributes or in an HTML start tag.
+
+### Async content
+
+> This functionality is considered experimental and a subject to change. For
+> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+
+The raw HTML can be wrapped in a `Promise`. When that happens, it will not
+render anything if it's pending or rejected. Once resolved, the resulting value
+is used. To have more fine-grained handling of non-resolved states, use `#let`
+and the async state helpers (e.g., `@pending`).
 
 ## Inclusion Tags
 


### PR DESCRIPTION
This is an extension of #424, where both async attributes and content are now supported. That means the following code is now correct:

```ts
Template.example.helpers({
  getClass: async () => 'dynamic',
  getContent: async () => 'Hello there!',
});
```

```html
<template name="example">
  <span class="static {{getClass}}">{{getContent}}</span>
</template>
```

Just like the `#if` and `#each` in #424, nothing is rendered until resolved. There's only one problem with async content - since a new view is created each time, the value may _flicker_. I decided to leave it for now and look into it later.

---

Note that async spread attributes, e.g., `<img {{attributes}}>` are NOT supported yet.