### PR TITLE
fix: remove unnecessary refererences in .versions

### DIFF
--- a/packages/blaze-hot/.versions
+++ b/packages/blaze-hot/.versions
@@ -8,7 +8,6 @@ caching-compiler@1.2.2
 caching-html-compiler@1.2.0
 check@1.3.1
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/blaze-hot/.versions
+++ b/packages/blaze-hot/.versions
@@ -27,7 +27,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reactive-var@1.0.11
 spacebars@1.1.0
 spacebars-compiler@1.2.0

--- a/packages/blaze-html-templates/.versions
+++ b/packages/blaze-html-templates/.versions
@@ -27,7 +27,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reactive-var@1.0.11
 spacebars@1.2.0
 spacebars-compiler@1.2.0

--- a/packages/blaze-html-templates/.versions
+++ b/packages/blaze-html-templates/.versions
@@ -8,7 +8,6 @@ caching-compiler@1.2.2
 caching-html-compiler@1.2.0
 check@1.3.1
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/blaze-tools/.versions
+++ b/packages/blaze-tools/.versions
@@ -12,7 +12,6 @@ ddp-client@2.4.0
 ddp-common@1.4.0
 ddp-server@2.3.2
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/blaze-tools/.versions
+++ b/packages/blaze-tools/.versions
@@ -38,7 +38,6 @@ npm-mongo@3.9.0
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.0

--- a/packages/blaze/.versions
+++ b/packages/blaze/.versions
@@ -43,7 +43,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0

--- a/packages/blaze/.versions
+++ b/packages/blaze/.versions
@@ -15,7 +15,6 @@ ddp-client@2.6.1
 ddp-common@1.4.0
 ddp-server@2.6.1
 diff-sequence@1.1.2
-dynamic-import@0.7.3
 ecmascript@0.16.7
 ecmascript-runtime@0.8.1
 ecmascript-runtime-client@0.12.1

--- a/packages/caching-html-compiler/.versions
+++ b/packages/caching-html-compiler/.versions
@@ -17,6 +17,5 @@ modules@0.16.0
 modules-runtime@0.12.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 spacebars-compiler@1.3.0
 templating-tools@1.2.1

--- a/packages/caching-html-compiler/.versions
+++ b/packages/caching-html-compiler/.versions
@@ -3,7 +3,6 @@ babel-runtime@1.5.0
 blaze-tools@1.1.2
 caching-compiler@1.2.2
 caching-html-compiler@1.2.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/html-tools/.versions
+++ b/packages/html-tools/.versions
@@ -12,7 +12,6 @@ ddp-client@2.4.0
 ddp-common@1.4.0
 ddp-server@2.3.2
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/html-tools/.versions
+++ b/packages/html-tools/.versions
@@ -38,7 +38,6 @@ npm-mongo@3.9.0
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.0

--- a/packages/htmljs/.versions
+++ b/packages/htmljs/.versions
@@ -36,7 +36,6 @@ npm-mongo@3.9.0
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.0

--- a/packages/htmljs/.versions
+++ b/packages/htmljs/.versions
@@ -11,7 +11,6 @@ ddp-client@2.4.0
 ddp-common@1.4.0
 ddp-server@2.3.2
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/observe-sequence/.versions
+++ b/packages/observe-sequence/.versions
@@ -11,7 +11,6 @@ ddp-client@2.6.1
 ddp-common@1.4.0
 ddp-server@2.6.1
 diff-sequence@1.1.2
-dynamic-import@0.7.3
 ecmascript@0.16.7
 ecmascript-runtime@0.8.1
 ecmascript-runtime-client@0.12.1

--- a/packages/observe-sequence/.versions
+++ b/packages/observe-sequence/.versions
@@ -36,7 +36,6 @@ observe-sequence@1.0.21
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.1

--- a/packages/spacebars-compiler/.versions
+++ b/packages/spacebars-compiler/.versions
@@ -12,7 +12,6 @@ ddp-client@2.4.0
 ddp-common@1.4.0
 ddp-server@2.3.2
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/spacebars-compiler/.versions
+++ b/packages/spacebars-compiler/.versions
@@ -38,7 +38,6 @@ npm-mongo@3.9.0
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.0

--- a/packages/spacebars-tests/.versions
+++ b/packages/spacebars-tests/.versions
@@ -45,7 +45,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reactive-dict@1.3.1
 reactive-var@1.0.12
 reload@1.3.1

--- a/packages/spacebars-tests/.versions
+++ b/packages/spacebars-tests/.versions
@@ -15,7 +15,6 @@ ddp-client@2.6.1
 ddp-common@1.4.0
 ddp-server@2.6.1
 diff-sequence@1.1.2
-dynamic-import@0.7.3
 ecmascript@0.16.7
 ecmascript-runtime@0.8.1
 ecmascript-runtime-client@0.12.1

--- a/packages/spacebars/.versions
+++ b/packages/spacebars/.versions
@@ -38,7 +38,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0

--- a/packages/spacebars/.versions
+++ b/packages/spacebars/.versions
@@ -12,7 +12,6 @@ ddp-client@2.6.1
 ddp-common@1.4.0
 ddp-server@2.6.1
 diff-sequence@1.1.2
-dynamic-import@0.7.3
 ecmascript@0.16.7
 ecmascript-runtime@0.8.1
 ecmascript-runtime-client@0.12.1

--- a/packages/templating-compiler/.versions
+++ b/packages/templating-compiler/.versions
@@ -3,7 +3,6 @@ babel-runtime@1.5.0
 blaze-tools@1.1.0
 caching-compiler@1.2.2
 caching-html-compiler@1.2.0
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/templating-compiler/.versions
+++ b/packages/templating-compiler/.versions
@@ -17,7 +17,6 @@ modules@0.16.0
 modules-runtime@0.12.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 spacebars-compiler@1.2.0
 templating-compiler@1.4.1
 templating-tools@1.2.0

--- a/packages/templating-runtime/.versions
+++ b/packages/templating-runtime/.versions
@@ -42,7 +42,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0

--- a/packages/templating-runtime/.versions
+++ b/packages/templating-runtime/.versions
@@ -15,7 +15,6 @@ ddp-client@2.6.1
 ddp-common@1.4.0
 ddp-server@2.6.1
 diff-sequence@1.1.2
-dynamic-import@0.7.3
 ecmascript@0.16.7
 ecmascript-runtime@0.8.1
 ecmascript-runtime-client@0.12.1

--- a/packages/templating-tools/.versions
+++ b/packages/templating-tools/.versions
@@ -12,7 +12,6 @@ ddp-client@2.4.0
 ddp-common@1.4.0
 ddp-server@2.3.2
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/templating-tools/.versions
+++ b/packages/templating-tools/.versions
@@ -38,7 +38,6 @@ npm-mongo@3.9.0
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reload@1.3.1
 retry@1.1.0
 routepolicy@1.1.0

--- a/packages/templating/.versions
+++ b/packages/templating/.versions
@@ -7,7 +7,6 @@ caching-compiler@1.2.2
 caching-html-compiler@1.2.0
 check@1.3.1
 diff-sequence@1.1.1
-dynamic-import@0.6.0
 ecmascript@0.15.1
 ecmascript-runtime@0.7.0
 ecmascript-runtime-client@0.11.0

--- a/packages/templating/.versions
+++ b/packages/templating/.versions
@@ -26,7 +26,6 @@ observe-sequence@1.0.16
 ordered-dict@1.1.0
 promise@0.11.2
 random@1.2.0
-react-fast-refresh@0.1.0
 reactive-var@1.0.11
 spacebars@1.2.0
 spacebars-compiler@1.2.0

--- a/test-app/.meteor/versions
+++ b/test-app/.meteor/versions
@@ -49,7 +49,6 @@ npm-mongo@4.16.0
 ordered-dict@1.1.0
 promise@0.12.2
 random@1.2.1
-react-fast-refresh@0.2.7
 reactive-var@1.0.12
 reload@1.3.1
 retry@1.1.0


### PR DESCRIPTION

There is no need to have dynamic-import or react-fast-refresh in .versions as it's never directly used within any of the Blaze packages. Must have been added by the host project. However, in order to advance with https://github.com/meteor/meteor/issues/10704 we also need to remove the reference here as well.