### PR TITLE
Deprecate UI package

### DIFF
--- a/packages/ui/package.js
+++ b/packages/ui/package.js
@@ -1,8 +1,9 @@
 Package.describe({
   name: 'ui',
   summary: "Deprecated: Use the 'blaze' package",
-  version: '1.0.13',
-  git: 'https://github.com/meteor/blaze.git'
+  version: '1.0.14',
+  git: 'https://github.com/meteor/blaze.git',
+  deprecated: true
 });
 
 Package.onUse(function (api) {


### PR DESCRIPTION
Has been in essence deprecated since Meteor v1, just making it official using the new param in package definition.

@Grubba27 for immediate independent release at your leisure.