### PR TITLE
Updated documentation about async APIs.

### DIFF
--- a/packages/htmljs/visitors.js
+++ b/packages/htmljs/visitors.js
@@ -173,7 +173,7 @@ TransformingVisitor.def({
 
     if (attrs && isConstructedObject(attrs)) {
       if (typeof attrs.then === 'function') {
-        throw new Error('Asynchronous attributes are not supported. Use #let to unwrap them first.');
+        throw new Error('Asynchronous dynamic attributes are not supported. Use #let to unwrap them first.');
       }
 
       throw new Error("The basic TransformingVisitor does not support " +

--- a/packages/spacebars-tests/async_tests.js
+++ b/packages/spacebars-tests/async_tests.js
@@ -57,7 +57,7 @@ asyncSuite('attribute', [
 asyncTest('attributes', '', async (test, template, render) => {
   Blaze._throwNextException = true;
   template.helpers({ x: Promise.resolve() });
-  test.throws(render, 'Asynchronous attributes are not supported. Use #let to unwrap them first.');
+  test.throws(render, 'Asynchronous dynamic attributes are not supported. Use #let to unwrap them first.');
 });
 
 asyncSuite('value_direct', [

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -174,15 +174,17 @@ Values returned from helpers must be pure text, not HTML.  (That is, strings
 should have `<`, not `&lt;`.)  Spacebars will perform any necessary escaping if
 a template is rendered to HTML.
 
-### Async content
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+### Async Content
 
 The values can be wrapped in a `Promise`. When that happens, it will be treated
 as `undefined` while it's pending or rejected. Once resolved, the resulting
 value is used. To have more fine-grained handling of non-resolved states, use
 `#let` and the async state helpers (e.g., `@pending`).
+
+> Please note that the values rendered this way create new `View` objects on
+> every `Promise` change and it may result in _flickering_, i.e., disappearing
+> for a brief moment before appearing again. We plan to optimize it in the next
+> versions. As a workaround, use `#let` to unpack the value.
 
 ### SafeString
 
@@ -203,10 +205,7 @@ An attribute value that consists entirely of template tags that return `null`,
 `undefined`, or `false` is considered absent; otherwise, the attribute is
 considered present, even if its value is empty.
 
-### Async attributes
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+### Async Attributes
 
 The values can be wrapped in a `Promise`. When that happens, it will be treated
 as `undefined` while it's pending or rejected. Once resolved, the resulting
@@ -240,10 +239,13 @@ To summarize:
   <tbody>
     <tr><td><code>""</code> or <code>null</code> or <code>{}</code></td></tr>
     <tr><td><code>"checked"</code> or <code>{checked: ""}</code></td><td><code>checked</code></td></tr>
-    <tr><td><code>{checked: "", 'class': "foo"}</code></td><td><code>checked  class=foo</code></td></tr>
+    <tr><td><code>{checked: "", 'class': "foo"}</code></td><td><code>checked class=foo</code></td></tr>
     <tr><td><code>{checked: false, 'class': "foo"}</code></td><td><code>class=foo</code></td></tr>
     <tr><td><code>"checked class=foo"</code></td><td>ERROR, string is not an attribute name</td></tr>
-    <tr><td><code>Promise.resolve({})</code></td><td>ERROR, asynchronous attributes are not supported</td></tr>
+    <tr>
+      <td><code>Promise.resolve({})</code></td>
+      <td>ERROR, asynchronous dynamic attributes are not supported, see <a href="https://github.com/meteor/blaze/issues/443"><code>#443</code></a></td>
+    </tr>
   </tbody>
 </table>
 
@@ -276,10 +278,7 @@ insert `"</div><div>"` to close an existing div and open a new one.
 
 This template tag cannot be used in attributes or in an HTML start tag.
 
-### Async content
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#424](https://github.com/meteor/blaze/pull/428).
+### Async Content
 
 The raw HTML can be wrapped in a `Promise`. When that happens, it will not
 render anything if it's pending or rejected. Once resolved, the resulting value
@@ -388,10 +387,7 @@ well as the empty array, while any other value is considered true.
 
 `#unless` is just `#if` with the condition inverted.
 
-### Async conditions
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#424](https://github.com/meteor/blaze/pull/424).
+### Async Conditions
 
 The condition can be wrapped in a `Promise`. When that happens, both `#if` and
 `#unless` will not render anything if it's pending or rejected. Once resolved,
@@ -464,10 +460,7 @@ context) if there are zero items in the sequence at any time.
 You can use a special variable `@index` in the body of `#each` to get the
 0-based index of the currently rendered value in the sequence.
 
-### Async sequences
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#424](https://github.com/meteor/blaze/pull/424).
+### Async Sequences
 
 The sequence argument can be wrapped in a `Promise`. When that happens, `#each`
 will render the "else" if it's pending or rejected. Once resolved, the resulting
@@ -523,10 +516,7 @@ any of the bindings is to one, the bound value won't be a `Promise`, but the
 resolved value instead. Both pending and rejected states will result in
 `undefined`.
 
-### Async states
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#412](https://github.com/meteor/blaze/pull/412).
+### Async States
 
 There are three global helpers used to query the state of the bound `Promise`s:
 * `@pending`, which checks whether any of the given bindings is still pending.
@@ -566,10 +556,7 @@ passing all bindings from the inner-most `#let`.
 {{/let}}
 ```
 
-### Async synchronization
-
-> This functionality is considered experimental and a subject to change. For
-> details please refer to [#412](https://github.com/meteor/blaze/pull/412).
+### Async Synchronization
 
 The bindings are **not** synchronized. That means, bindings store that _latest
 resolved value_, not _value of the latest `Promise`_. If the resolution time


### PR DESCRIPTION
In this PR, I removed all mentions of async APIs being experimental, and clarified the imperfection of directly rendering async content. This should be the last step before _actually_ releasing async Blaze!