### PR TITLE
Revert "Updating dependencies for templating-compiler package"

### DIFF
--- a/packages/templating-compiler/package.js
+++ b/packages/templating-compiler/package.js
@@ -9,9 +9,9 @@ Package.describe({
 Package.registerBuildPlugin({
   name: "compileTemplatesBatch",
   use: [
-    'ecmascript@0.16.7',
-    'caching-html-compiler@1.2.1',
-    'templating-tools@1.2.2'
+    'ecmascript@0.15.1',
+    'caching-html-compiler@1.2.0',
+    'templating-tools@1.2.0'
   ],
   sources: [
     'compile-templates.js'


### PR DESCRIPTION
Reverts meteor/blaze#435

I thought it was pointing to 2.8 branch