### PR TITLE
Implemented async dynamic attributes (closes #443).

### DIFF
--- a/packages/blaze/exceptions.js
+++ b/packages/blaze/exceptions.js
@@ -42,6 +42,13 @@ Blaze._reportException = function (e, msg) {
   debugFunc()(msg || 'Exception caught in template:', e.stack || e.message || e);
 };
 
+// It's meant to be used in `Promise` chains to report the error while not
+// "swallowing" it (i.e., the chain will still reject).
+Blaze._reportExceptionAndThrow = function (error) {
+  Blaze._reportException(error);
+  throw error;
+};
+
 Blaze._wrapCatchingExceptions = function (f, where) {
   if (typeof f !== 'function')
     return f;

--- a/packages/blaze/materializer.js
+++ b/packages/blaze/materializer.js
@@ -104,9 +104,9 @@ function then(maybePromise, fn) {
 }
 
 function waitForAllAttributes(attrs) {
-  if (attrs !== Object(attrs)) {
-    console.log(attrs)
-    return attrs;
+  // Non-object attrs (e.g., `null`) are ignored.
+  if (!attrs || attrs !== Object(attrs)) {
+    return {};
   }
 
   // Combined attributes, e.g., `<img {{x}} {{y}}>`.

--- a/packages/htmljs/visitors.js
+++ b/packages/htmljs/visitors.js
@@ -10,6 +10,7 @@ import {
   isVoidElement,
 } from './html';
 
+const isPromiseLike = x => !!x && typeof x.then === 'function';
 
 var IDENTITY = function (x) { return x; };
 
@@ -156,6 +157,11 @@ TransformingVisitor.def({
   // an array, or in some uses, a foreign object (such as
   // a template tag).
   visitAttributes: function (attrs, ...args) {
+    // Allow Promise-like values here; these will be handled in materializer.
+    if (isPromiseLike(attrs)) {
+      return attrs;
+    }
+
     if (isArray(attrs)) {
       var result = attrs;
       for (var i = 0; i < attrs.length; i++) {
@@ -172,10 +178,6 @@ TransformingVisitor.def({
     }
 
     if (attrs && isConstructedObject(attrs)) {
-      if (typeof attrs.then === 'function') {
-        throw new Error('Asynchronous dynamic attributes are not supported. Use #let to unwrap them first.');
-      }
-
       throw new Error("The basic TransformingVisitor does not support " +
                       "foreign objects in attributes.  Define a custom " +
                       "visitAttributes for this case.");

--- a/packages/spacebars-tests/async_tests.html
+++ b/packages/spacebars-tests/async_tests.html
@@ -76,6 +76,10 @@
   <img {{x}}>
 </template>
 
+<template name="spacebars_async_tests_attributes_double">
+  <img {{x}} {{y}}>
+</template>
+
 <template name="spacebars_async_tests_value_direct">
   {{x}}
 </template>

--- a/packages/spacebars/spacebars-runtime.js
+++ b/packages/spacebars/spacebars-runtime.js
@@ -131,12 +131,14 @@ Spacebars.makeRaw = function (value) {
 function _thenWithContext(promise, fn) {
   const computation = Tracker.currentComputation;
   const view = Blaze.currentView;
-  return promise.then(value =>
-    Blaze._withCurrentView(view, () =>
-      Tracker.withComputation(computation, () =>
-        fn(value)
-      )
-    )
+  return promise.then(
+    value =>
+      Blaze._withCurrentView(view, () =>
+        Tracker.withComputation(computation, () =>
+          fn(value)
+        )
+      ),
+    Blaze._reportExceptionAndThrow
   );
 }
 

--- a/site/source/api/spacebars.md
+++ b/site/source/api/spacebars.md
@@ -228,7 +228,7 @@ and value strings. For convenience, the value may also be a string or null. An
 empty string or null expands to `{}`. A non-empty string must be an attribute
 name, and expands to an attribute with an empty value; for example, `"checked"`
 expands to `{checked: ""}` (which, as far as HTML is concerned, means the
-checkbox is checked). `Promise`s are not supported and will throw an error.
+checkbox is checked).
 
 To summarize:
 
@@ -242,10 +242,6 @@ To summarize:
     <tr><td><code>{checked: "", 'class': "foo"}</code></td><td><code>checked class=foo</code></td></tr>
     <tr><td><code>{checked: false, 'class': "foo"}</code></td><td><code>class=foo</code></td></tr>
     <tr><td><code>"checked class=foo"</code></td><td>ERROR, string is not an attribute name</td></tr>
-    <tr>
-      <td><code>Promise.resolve({})</code></td>
-      <td>ERROR, asynchronous dynamic attributes are not supported, see <a href="https://github.com/meteor/blaze/issues/443"><code>#443</code></a></td>
-    </tr>
   </tbody>
 </table>
 
@@ -262,6 +258,12 @@ specifies a value for the `class` attribute, it will overwrite `{% raw %}{{myCla
 As always, Spacebars takes care of recalculating the element's attributes if any
 of `myClass`, `attrs1`, or `attrs2` changes reactively.
 
+### Async Dynamic Attributes
+
+The dynamic attributes can be wrapped in a `Promise`. When that happens, they
+will be treated as `undefined` while it's pending or rejected. Once resolved,
+the resulting value is used. To have more fine-grained handling of non-resolved
+states, use `#let` and the async state helpers (e.g., `@pending`).
 
 ## Triple-braced Tags
 


### PR DESCRIPTION
In this pull request, I added support for async dynamic attributes, i.e., `<img {{getAttributesAsync}}>`. As usual, while the `Promise` is still pending or rejected, an empty state is rendered, i.e., with no attributes at all.

**EDIT 2024-01-24:** As in [this discussion](https://github.com/meteor/blaze/pull/460/files/a08373c5e60f9fde9e8268e5ba748b4f76d3c0b5#diff-bf43372770fd37ca51fcb7ff881dee72730e4bb0a61e2a041c7ff61836c13aea), I also added error handling to all async-related logic. It's based on the `Blaze._reportException` helper.