### PR TITLE
Fix typo in error message.

### DIFF
--- a/packages/blaze/domrange.js
+++ b/packages/blaze/domrange.js
@@ -337,7 +337,7 @@ DOMRange.prototype.containsElement = function (elem, selector, event) {
   ? this.view.name.split('.')[1]
   : 'unknown template';
   if (! this.attached)
-    throw new Error(`${event} event triggerd with ${selector} on ${templateName} but associated view is not be found.
+    throw new Error(`${event} event triggered with ${selector} on ${templateName} but associated view is not be found.
     Make sure the event doesn't destroy the view.`);
 
   // An element is contained in this DOMRange if it's possible to

--- a/packages/blaze/view_tests.js
+++ b/packages/blaze/view_tests.js
@@ -73,7 +73,7 @@ if (Meteor.isClient) {
   // correctly about it's root cause, when throwing due to an event
   Tinytest.add("blaze - view - attached", function (test) {
     test.throws(() => Blaze._DOMRange.prototype.containsElement.call({attached: false, view: {name: 'Template.foo'}}, undefined, '.class', 'click'),
-    `click event triggerd with .class on foo but associated view is not be found.
+    `click event triggered with .class on foo but associated view is not be found.
     Make sure the event doesn't destroy the view.`);
   });
 }


### PR DESCRIPTION
This fixes a small typo in an error message: "triggerd" should be "triggered".