### PR TITLE
Added support for `Promise`s in `#with` (closes #469).

### DIFF
--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -305,7 +305,7 @@ Blaze.Each = function (argFunc, contentFunc, elseFunc) {
             if (eachView.variableName) {
               itemView._scopeBindings[eachView.variableName].set({ value: newItem });
             } else {
-              itemView.dataVar.set(newItem);
+              itemView.dataVar.set({ value: newItem });
             }
           }
         });

--- a/packages/blaze/builtins.js
+++ b/packages/blaze/builtins.js
@@ -16,17 +16,9 @@ Blaze._calculateCondition = function (cond) {
 Blaze.With = function (data, contentFunc) {
   const view = Blaze.View('with', contentFunc);
 
-  view.dataVar = new ReactiveVar();
-
-  view.onViewCreated(function () {
-    if (typeof data === 'function') {
-      // `data` is a reactive function
-      view.autorun(function () {
-        view.dataVar.set(data());
-      }, view.parentView, 'setData');
-    } else {
-      view.dataVar.set(data);
-    }
+  view.dataVar = null;
+  view.onViewCreated(() => {
+    view.dataVar = _createBinding(view, data, 'setData');
   });
 
   return view;

--- a/packages/blaze/lookup.js
+++ b/packages/blaze/lookup.js
@@ -278,8 +278,8 @@ Blaze._parentData = function (height, _functionWrapped) {
   if (! theWith)
     return null;
   if (_functionWrapped)
-    return function () { return theWith.dataVar.get(); };
-  return theWith.dataVar.get();
+    return function () { return theWith.dataVar.get()?.value; };
+  return theWith.dataVar.get()?.value;
 };
 
 

--- a/packages/blaze/view.js
+++ b/packages/blaze/view.js
@@ -792,7 +792,7 @@ Blaze.getData = function (elementOrView) {
     throw new Error("Expected DOM element or View");
   }
 
-  return theWith ? theWith.dataVar.get() : null;
+  return theWith ? theWith.dataVar.get()?.value : null;
 };
 
 // For back-compat

--- a/packages/spacebars-tests/async_tests.html
+++ b/packages/spacebars-tests/async_tests.html
@@ -105,3 +105,7 @@
 <template name="spacebars_async_tests_each_new">
   {{#each y in x}}{{y}}{{else}}0{{/each}}
 </template>
+
+<template name="spacebars_async_tests_with">
+  {{#with x}}{{y}}{{/with}}
+</template>

--- a/packages/templating-runtime/templating.js
+++ b/packages/templating-runtime/templating.js
@@ -138,7 +138,7 @@ Template._applyHmrChanges = function (templateName) {
           var newView = Blaze.render(Template.body, document.body, comment);
           Template.body.view = newView;
         } else if (view.dataVar) {
-          Blaze.renderWithData(renderFunc, view.dataVar.curValue, parentEl, comment);
+          Blaze.renderWithData(renderFunc, view.dataVar.curValue?.value, parentEl, comment);
         } else {
           Blaze.render(renderFunc, parentEl, comment);
         }


### PR DESCRIPTION
As mentioned in https://github.com/meteor/blaze/issues/469#issuecomment-2330739031, this PR adds support for `Promise`s in `#with` blocks, just like #424 did that for `#if` and `#each`.

Note that due to the way `#with` is implemented, it takes two "cycles" (i.e., `await`s) to fully propagate those results. That should not be a problem, as [`#with` is discouraged anyway](https://www.blazejs.org/guide/spacebars#Each-and-With).