### PR TITLE
Fix GitHub spelling

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -16,6 +16,6 @@ Before reporting a bug, please check for existing or closed issues first.
 - [ ] The expected behavior.
 - [ ] The actual behavior.
 - [ ] A **simple** reproduction! (Must either include a minimal code example
-or a link to a Github repository with steps to reproduce the issue on it.)
+or a link to a GitHub repository with steps to reproduce the issue on it.)
 
 -->

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Support us with a monthly donation and help us continue our activities. [Become 
 
 ## Sponsors
 
-Become a sponsor and get your logo on our README on Github with a link to your site. [Become a sponsor](https://opencollective.com/blaze#sponsor).
+Become a sponsor and get your logo on our README on GitHub with a link to your site. [Become a sponsor](https://opencollective.com/blaze#sponsor).
 
 <a href="https://opencollective.com/blaze/sponsor/0/website" target="_blank"><img src="https://opencollective.com/blaze/sponsor/0/avatar.svg"></a>
 <a href="https://opencollective.com/blaze/sponsor/1/website" target="_blank"><img src="https://opencollective.com/blaze/sponsor/1/avatar.svg"></a>


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.