### PR TITLE
Replace jquery parseHTML with native alternative

### DIFF
--- a/packages/blaze/dombackend.js
+++ b/packages/blaze/dombackend.js
@@ -54,6 +54,19 @@ DOMBackend.parseHTML = function(html, context) {
     optgroup: { parent: 'select', context: 'div' }
   };
   
+  html = html.trim();
+  
+  // Return empty array for empty strings after trim
+  if (!html) {
+    return [];
+  }
+  
+  // Check if the string contains any HTML
+  if (!/(<|&(?:[a-z\d]+|#\d+|#x[a-f\d]+);)/i.test(html)) {
+    // Plain text, create a text node
+    return [context.createTextNode(html)];
+  }
+  
   // Simple regex to get the first tag
   const firstTagMatch = /<([a-z][^\/\0>\x20\t\r\n\f]*)/i.exec(html);
   
@@ -66,18 +79,13 @@ DOMBackend.parseHTML = function(html, context) {
       const parentElement = context.createElement(spec.parent);
       contextElement.appendChild(parentElement);
       parentElement.innerHTML = html;
-      return Array.from(parentElement.childNodes);
+      return Array.prototype.slice.call(parentElement.childNodes);
     }
   }
   
-  // IE-compatible parsing
+  // Handle regular HTML and self-closing tags
   const div = context.createElement('div');
-  
-  // Trim whitespace to avoid IE's automatic wrapping
-  html = html.trim();
-  
-  // Wrap in div and set innerHTML
-  div.innerHTML = html;
+  div.innerHTML = html.replace(/<([\w:-]+)\/>/g, '<$1></$1>');
   
   // Convert childNodes to array for consistency
   // Use Array.prototype.slice for IE compatibility

--- a/packages/blaze/render_tests.js
+++ b/packages/blaze/render_tests.js
@@ -895,32 +895,38 @@ Tinytest.add("blaze - dombackend - parseHTML", function (test) {
       `${testCaseName}: Expected ${testCase.expectedTags[0]} but got ${firstNode.nodeName}`);
   });
 
-  // // Test whitespace handling (IE is sensitive to this)
-  // const whitespaceTestCases = [
-  //   {
-  //     html: "  <div>Padded</div>  ",
-  //     expectedLength: 1,
-  //     expectedTag: "DIV"
-  //   },
-  //   {
-  //     html: "\n<div>Newlines</div>\n",
-  //     expectedLength: 1,
-  //     expectedTag: "DIV"
-  //   },
-  //   {
-  //     html: "\t<div>Tabs</div>\t",
-  //     expectedLength: 1,
-  //     expectedTag: "DIV"
-  //   }
-  // ];
+  // Test whitespace handling (IE is sensitive to this)
+  const whitespaceTestCases = [
+    {
+      html: "  <div>Padded</div>  ",
+      expectedLength: 3,  // Leading space + div + trailing space
+      expectedTag: "DIV"
+    },
+    {
+      html: "\n<div>Newlines</div>\n",
+      expectedLength: 3,  // Leading newline + div + trailing newline
+      expectedTag: "DIV"
+    },
+    {
+      html: "\t<div>Tabs</div>\t",
+      expectedLength: 3,  // Leading tab + div + trailing tab
+      expectedTag: "DIV"
+    }
+  ];
 
-  // whitespaceTestCases.forEach((testCase, i) => {
-  //   const result = Blaze._DOMBackend.parseHTML(testCase.html);
-  //   test.equal(result.length, testCase.expectedLength,
-  //     `Whitespace test ${i}: Expected length ${testCase.expectedLength} but got ${result.length}`);
-  //   test.equal(result[0].nodeName, testCase.expectedTag,
-  //     `Whitespace test ${i}: Expected tag ${testCase.expectedTag} but got ${result[0].nodeName}`);
-  // });
+  whitespaceTestCases.forEach((testCase, i) => {
+    const result = Blaze._DOMBackend.parseHTML(testCase.html);
+    test.equal(result.length, testCase.expectedLength,
+      `Whitespace test ${i}: Expected length ${testCase.expectedLength} but got ${result.length}`);
+    // Check the middle node (the div)
+    test.equal(result[1].nodeName, testCase.expectedTag,
+      `Whitespace test ${i}: Expected tag ${testCase.expectedTag} but got ${result[1].nodeName}`);
+    // Verify surrounding nodes are text nodes
+    test.equal(result[0].nodeType, Node.TEXT_NODE,
+      `Whitespace test ${i}: Expected leading text node`);
+    test.equal(result[2].nodeType, Node.TEXT_NODE,
+      `Whitespace test ${i}: Expected trailing text node`);
+  });
 
   // Test empty input
   test.equal(Blaze._DOMBackend.parseHTML("").length, 0);

--- a/packages/blaze/render_tests.js
+++ b/packages/blaze/render_tests.js
@@ -794,6 +794,26 @@ Tinytest.add("blaze - dombackend - parseHTML", function (test) {
   test.equal(basicResult[0].nodeName, "DIV");
   test.equal(basicResult[0].textContent || basicResult[0].innerText, "Hello");  // innerText for IE
 
+  // Test plain text (no HTML)
+  const textOnly = "Just some text";
+  const textResult = Blaze._DOMBackend.parseHTML(textOnly);
+  test.equal(textResult.length, 1);
+  test.equal(textResult[0].nodeType, Node.TEXT_NODE);
+  test.equal(textResult[0].textContent || textResult[0].nodeValue, "Just some text");
+
+  // Test self-closing tags
+  const selfClosing = "<div/>Content";
+  const selfClosingResult = Blaze._DOMBackend.parseHTML(selfClosing);
+  test.equal(selfClosingResult.length, 2);
+  test.equal(selfClosingResult[0].nodeName, "DIV");
+  test.equal(selfClosingResult[1].nodeType, Node.TEXT_NODE);
+
+  // Test nested table elements (testing proper wrapping levels)
+  const nestedTable = "<td>Cell</td>";
+  const nestedResult = Blaze._DOMBackend.parseHTML(nestedTable);
+  test.equal(nestedResult.length, 1);
+  test.equal(nestedResult[0].nodeName, "TD");
+
   // Test table elements (IE has special requirements)
   const tableTestCases = {
     tr: {


### PR DESCRIPTION
Decoupling jQuery and Blaze would take substantial effort. jQuery is used in many places:

1. HTML Parsing 
```js
DOMBackend.parseHTML = function (html) {
  return $jq.parseHTML(html, DOMBackend.getContext()) || [];
};
```
2. DOM Selection
```js
findBySelector: function (selector, context) {
  return $jq(selector, context);
}
```
3. Basic DOM Manipulation
```js
$jq(elem).remove();
$jq(elem).append(child);
```

4. Element Teardown Detection
```js
$jq.event.special[DOMBackend.Teardown._JQUERY_EVENT_NAME]
```

5. Event Delegation 
```js
delegateEvents: function (elem, type, selector, handler) {
  $jq(elem).on(type, selector, handler);
}
```

I've ranked them in terms of ease of replacement, and impact. The challenge lies mostly in testing and ensuring cross browser compatibility so it's best to merge each change individually, do a minor release, test then repeat until all is merged then we can do a major release.

I chose to start off with [parseHTML](https://api.jquery.com/jQuery.parseHTML/). It can already be replaced with [createHTMLDocument]( https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation/createHTMLDocument) as suggested [here](https://youmightnotneedjquery.com/#parse_html). So I chose a middle approach where `createHTMLDocument` is used only if it succeeds with a fallback code that works with IE. 

I've relied on this [implementation](https://gist.github.com/Munawwar/6e6362dbdf77c7865a99) and the official [tests](https://github.com/jquery/jquery/blob/4466770992d5833358169d0248c4deedadea1a96/test/unit/core.js#L1352) in constructing the new tests to ensure backwards compatibility.   

  

