### PR TITLE
fix(blaze): rename reserved arguments parameter to fix SWC transpilation

### DIFF
--- a/packages/blaze/exceptions.js
+++ b/packages/blaze/exceptions.js
@@ -28,12 +28,12 @@ Blaze._reportException = function (e, msg) {
     throw e;
   }
 
-  if (! debugFunc)
+  if (!debugFunc)
     // adapted from Tracker
     debugFunc = function () {
       return (typeof Meteor !== "undefined" ? Meteor._debug :
-              ((typeof console !== "undefined") && console.log ? console.log :
-               function () {}));
+        ((typeof console !== "undefined") && console.log ? console.log :
+          function () { }));
     };
 
   // In Chrome, `e.stack` is a multiline string that starts with the message


### PR DESCRIPTION
## Summary

  - Fix SWC transpilation failure in `blaze/exceptions.js` caused by using `arguments` as a rest parameter name (`...arguments`), which is a reserved identifier in strict mode
  - Rename `...arguments` to `...args` in `Blaze._wrapCatchingExceptions`
 
<img width="692" height="180" alt="Screenshot 2026-04-24 at 1 43 48 PM" src="https://github.com/user-attachments/assets/81bb9999-809d-4148-a06b-7102f73166e4" />


  ## Problem

  The SWC transpiler fails to parse `blaze/exceptions.js` because `arguments` cannot be used as a binding identifier in strict mode (ES module context). This causes a fallback to Babel with the error:

  [Transpiler] Used Babel for blaze/exceptions.js (package) ⚠️  Fallback
    ↳ Error: x 'eval' and 'arguments' cannot be used as a binding identifier in strict mode

  This error is currently occurring in CI ([see failing job](https://github.com/meteor/meteor/actions/runs/24890038256/job/72885430668?pr=14112)) and can be reproduced locally by running:

  ```bash
  cd tools/modern-tests
  npm test -- -t=Blaze

  Fix

  Renamed the rest parameter from ...arguments to ...args in Blaze._wrapCatchingExceptions. This is a safe rename since the function already used spread syntax, arguments was being shadowed as a regular parameter, not used as the implicit arguments object.

  Test plan

  - Run `npm test -- -t=Blaze` in `tools/modern-tests` and confirm `blaze/exceptions.js` no longer falls back to Babel
  - Verify the function behavior is unchanged (spread args passed through f.apply(this, args))