### PR TITLE
fix(blaze): match delegated event selectors within delegation root

### DIFF
--- a/packages/blaze/dombackend.js
+++ b/packages/blaze/dombackend.js
@@ -145,30 +145,34 @@ DOMBackend.Events = {
 };
 
 const createWrapper = (elem, type, selector, handler) => {
+    // jQuery delegation evaluates the selector rooted at the delegation
+    // element ($(elem).find(selector)): for 'div p', both the div and the p
+    // must live inside `elem`. A bare closest(selector) matches against the
+    // whole document, letting ancestors outside `elem` satisfy the selector.
+    const scopedSelector = selector
+        .split(',')
+        .map((part) => `:scope ${part}`)
+        .join(',');
+
     return (event) => {
         // event.target can be a text node (nodeType 3) — walk to parent element first
-        const origin = event.target;
-        const target = origin.nodeType === 1 ? origin.closest(selector) : origin.parentElement?.closest(selector);
+        const origin = event.target.nodeType === 1 ? event.target : event.target.parentElement;
+        if (!origin) return;
 
-        // we need to manually check, if a selector left the template scope
-        // which jQuery would do automatically for us.
-        // for this we traverse nodes that still match the selector
-        // and compare the final to see, if the event bubbled up to
-        // a parent view that is out of scope
-        let node = origin;
-        while (node && node !== elem && node instanceof Element && node.matches(selector)) {
-            node = node.parentElement;
+        const matches = new Set(elem.querySelectorAll(scopedSelector));
+
+        // closest ancestor-or-self of the target that the scoped selector
+        // matches — the element jQuery would pick as currentTarget. `elem`
+        // itself is excluded: delegated handlers only fire on descendants.
+        let target = null;
+        for (let node = origin; node && node !== elem; node = node.parentElement) {
+            if (matches.has(node)) {
+                target = node;
+                break;
+            }
         }
 
-        const root = elem?.['$blaze_range']?.view?.name;
-        const scope = node?.['$blaze_range']?.view?.name;
-
-        let inScope = true;
-        if (root && scope && root === scope) {
-            inScope = false;
-        }
-
-        if (target && elem.contains(target) && inScope) {
+        if (target) {
             // Mimic jQuery's delegated event behavior
             Object.defineProperty(event, 'currentTarget', {
                 value: target,

--- a/packages/spacebars-tests/template_tests.html
+++ b/packages/spacebars-tests/template_tests.html
@@ -1172,3 +1172,25 @@ Hi there!
     <div>{{item}}</div>
   {{/each}}
 </template>
+
+<template name="spacebars_test_event_scope_collision_parent">
+  {{#if show}}
+    <div class="wrapper">{{> spacebars_test_event_scope_collision_child}}</div>
+  {{/if}}
+</template>
+
+<template name="spacebars_test_event_scope_collision_child">
+  {{#if show}}
+    <nav><button type="button" class="hit">go</button></nav>
+  {{/if}}
+</template>
+
+<template name="spacebars_test_event_scope_direct_parent">
+  <div class="wrapper">{{> spacebars_test_event_scope_direct_child}}</div>
+</template>
+
+<template name="spacebars_test_event_scope_direct_child">
+  {{#if show}}
+    <button type="button" class="hit">go</button>
+  {{/if}}
+</template>

--- a/packages/spacebars-tests/template_tests.js
+++ b/packages/spacebars-tests/template_tests.js
@@ -4480,3 +4480,50 @@ Tinytest.add(
     );
   }
 );
+
+// Regression tests for meteor/blaze#512 — the native (no-jQuery) backend's
+// delegation scope check compared `$blaze_range.view.name` strings, so a
+// delegated event was silently dropped whenever the delegation root's range
+// name matched the range name at the event's scope boundary.
+Tinytest.add(
+  'spacebars-tests - template_tests - delegated event fires in inclusion wrapped by an element inside {{#if}} (#512)',
+  function (test) {
+    const parent = Template.spacebars_test_event_scope_collision_parent;
+    const child = Template.spacebars_test_event_scope_collision_child;
+    parent.helpers({ show: () => true });
+    child.helpers({ show: () => true });
+    const buf = [];
+    child.events({
+      'click .hit': function (evt) {
+        buf.push(evt.currentTarget.className);
+      },
+    });
+
+    const div = renderToDiv(parent);
+    document.body.appendChild(div);
+    clickIt(div.querySelector('.hit'));
+    test.equal(buf.join(), 'hit');
+    document.body.removeChild(div);
+  }
+);
+
+Tinytest.add(
+  'spacebars-tests - template_tests - delegated event fires on direct child of a wrapper element (#512)',
+  function (test) {
+    const parent = Template.spacebars_test_event_scope_direct_parent;
+    const child = Template.spacebars_test_event_scope_direct_child;
+    child.helpers({ show: () => true });
+    const buf = [];
+    child.events({
+      'click .hit': function (evt) {
+        buf.push(evt.currentTarget.className);
+      },
+    });
+
+    const div = renderToDiv(parent);
+    document.body.appendChild(div);
+    clickIt(div.querySelector('.hit'));
+    test.equal(buf.join(), 'hit');
+    document.body.removeChild(div);
+  }
+);


### PR DESCRIPTION
Fixes #512.

The native (no-jQuery) backend decided delegation scope by comparing `$blaze_range.view.name` strings between the delegation root and the node where the selector stopped matching. Block helper views share generic names (`'if'`, `'unless'`, …), so a wrapper element inside a parent's `{{#if}}` collided with the child template's own `{{#if}}` and the event was silently dropped (#512 has the verified 8-case matrix; when the clicked element is a direct child of the delegation root, both names are even read off the same element, dropping the event for any tagged wrapper regardless of names).

The heuristic was approximating jQuery's context-rooted selector matching (the "event map selector scope" tests: for `'div p'`, both elements must live inside the delegation root — `$(elem).find(selector)` semantics). This PR implements that semantics directly instead: prefix the selector with `:scope`, query from the delegation element, and pick the closest matching ancestor-or-self of the event target (root excluded, as jQuery does). The name comparison is gone.

Notes:

- Two regression tests added (watched fail before the fix: `expected "hit", actual ""`); existing tests untouched — in particular the "event map selector scope" tests now pass for the right reason.
- Full suite green on both backends via the CI method (`test-in-console` + `puppeteerRunner`): native 416/416, jQuery 420/420.
- Per-event `querySelectorAll` cost is equivalent to what jQuery's Sizzle did per delegated event on this same path; it only runs when jQuery is absent, and only for delegated (selector) handlers.
- `:scope` is supported by every browser Meteor 3 targets, and the test suite itself already relies on it (`querySelectorAll(':scope > *')`).
